### PR TITLE
Downgrade minSdkVersion to 7 to run on Nook Simple Touch

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "fr.gaulupeau.apps.InThePoche"
-        minSdkVersion 8
+        minSdkVersion 7
         targetSdkVersion 20
         versionCode 9
         versionName "1.6"
@@ -16,6 +16,9 @@ android {
             runProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+    lintOptions {
+	    abortOnError false
     }
 }
 


### PR DESCRIPTION
Also, disable lint abortOnError so the build completes despite
getActionBar().setDisplayHomeAsUpEnabled(true) calls (properly protected
by conditions on the API version in the code).

fixes: wallabag/android-app#25

Signed-off-by: Olivier Mehani shtrom@ssji.net
