### PR TITLE
Add Poche::getDatabase to prevent overwriting reference, leading to a leak

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/Poche.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/Poche.java
@@ -217,7 +217,7 @@ public class Poche extends Activity {
 		if (pref.getInt("update_checker", 0) < 9) {
 			// Wipe Database, because we now save HTML content instead of plain text
 			ArticlesSQLiteOpenHelper helper = new ArticlesSQLiteOpenHelper(this);
-			database = helper.getReadableDatabase();
+			getDatabase();
 			helper.truncateTables(database);
 			showToast("Update: Wiped Database. Please synchronize.");
 		}
@@ -237,6 +237,13 @@ public class Poche extends Activity {
 		pocheUrl = settings.getString("pocheUrl", "http://");
 		apiUsername = settings.getString("APIUsername", "");
 		apiToken = settings.getString("APIToken", "");
+	}
+
+	private void getDatabase() {
+		if (database == null) {
+			ArticlesSQLiteOpenHelper helper = new ArticlesSQLiteOpenHelper(this);
+			database = helper.getReadableDatabase();
+		}
 	}
 
 	@Override
@@ -259,8 +266,7 @@ public class Poche extends Activity {
 	private void updateUnread() {
 		runOnUiThread(new Runnable() {
 			public void run() {
-				ArticlesSQLiteOpenHelper helper = new ArticlesSQLiteOpenHelper(getApplicationContext());
-				database = helper.getReadableDatabase();
+				getDatabase();
 				int news = database.query(ARTICLE_TABLE, null, ARCHIVE + "=0", null, null, null, null).getCount();
 				btnGetPost.setText(String.format(getString(R.string.btnGetPost), news));
 			}


### PR DESCRIPTION
NOTA: This is not thoroughly tested, but this seems to fix the problem, while not causing any other.

Fixes the following exception

    java.lang.IllegalStateException: /data/data/fr.gaulupeau.apps.InThePoche/databases/article_db.sqlite SQLiteDatabase created and never closed

Signed-off-by: Olivier Mehani <shtrom@ssji.net>