### PR TITLE
High contrast

### DIFF
--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -16,6 +16,7 @@ html {
 
 body {
   background: #EEE;
+  font-family: serif;
 }
 
 .hicontrast {

--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -18,6 +18,11 @@ body {
   background: #EEE;
 }
 
+.hicontrast {
+  background: #FFF;
+  font-weight: 600;
+}
+
 /* ==========================================================================
    1 = Style Guide
    ========================================================================== */
@@ -34,6 +39,12 @@ h2, h3, h4 {
 
 p, li {
   color: #666;
+}
+
+.hicontrast p,
+.hicontrast li {
+  color: #000;
+  background: #FFF;
 }
 
 a {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ReadArticle.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ReadArticle.java
@@ -69,6 +69,11 @@ public class ReadArticle extends BaseActionBarActivity {
 			//
 		}
 
+		Boolean hicontrast = false;
+		if (android.os.Build.MODEL.equals("NOOK")) {
+			hicontrast = true;
+		}
+
 		String htmlHeader = "<html>\n" +
 				"\t<head>\n" +
 				"\t\t<meta name=\"viewport\" content=\"initial-scale=1.0, maximum-scale=1.0, user-scalable=no\" />\n" +
@@ -77,7 +82,7 @@ public class ReadArticle extends BaseActionBarActivity {
 				"\t\t<link rel=\"stylesheet\" href=\"ratatouille.css\" media=\"all\" id=\"extra-theme\">\n" +
 				"\t</head>\n" +
 				"\t\t<div id=\"main\">\n" +
-				"\t\t\t<body>\n" +
+				"\t\t\t<body" + (hicontrast?" class=\"hicontrast\"":"") + ">\n" +
 				"\t\t\t\t<div id=\"content\" class=\"w600p center\">\n" +
 				"\t\t\t\t\t<div id=\"article\">\n" +
 				"\t\t\t\t\t\t<header class=\"mbm\">\n" +


### PR DESCRIPTION
Just so this is not lost: This PR tweaks the article CSS a bit to force high-contrast colours. This is useful on e-ink readers such as the Nook, where text is otherwise a bit hard to read sometimes. This is done by adding the relevant CSS class to the article.

At the moment, this is done only if a Nook is detected. This should probably be done in the settings somewhere, or at list with a list of known devices.

So, not a very functional patch at this point (though it doesn't break anything), but it can prove a useful thing to have in the future.