### PR TITLE
Fix NPE in case of null username or password

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagService.java
@@ -172,9 +172,10 @@ public class WallabagService {
     private Request getLoginRequest() {
         String url = endpoint + "/?login";
 
+        // TODO: maybe move null checks somewhere else
         RequestBody formBody = new FormEncodingBuilder()
-                .add("login", username)
-                .add("password", password)
+                .add("login", username != null ? username : "")
+                .add("password", password != null ? password : "")
 //                .add("longlastingsession", "on")
                 .build();
 


### PR DESCRIPTION
Should fix #148.
More credentials checks should be added in the future (to advice user to check settings rather than saying about network/authorization errors).