### PR TITLE
Updates

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -23,6 +23,7 @@ public class Settings {
     public static final String HTTP_AUTH_USERNAME = "http_auth_username";
     public static final String HTTP_AUTH_PASSWORD = "http_auth_password";
     public static final String THEME = "theme";
+    public static final String CONFIGURE_OPTIONAL_DIALOG_SHOWN = "configure_optional_dialog_shown";
 
     private SharedPreferences pref;
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/AddLinkTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/AddLinkTask.java
@@ -25,7 +25,7 @@ public class AddLinkTask extends AsyncTask<Void, Void, Boolean> {
     private String errorMessage;
     private Context context;
     private ProgressBar progressBar;
-    private ProgressDialog progressDialog;
+    private ProgressDialog progressDialog; // TODO: remove
 
     private boolean isOffline;
     private boolean savedOffline;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/AddLinkTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/AddLinkTask.java
@@ -51,27 +51,33 @@ public class AddLinkTask extends AsyncTask<Void, Void, Boolean> {
     protected Boolean doInBackground(Void... params) {
         boolean result = false;
 
+        isOffline = true;
+
         if(WallabagConnection.isNetworkOnline()) {
             Settings settings = App.getInstance().getSettings();
-            WallabagService service = new WallabagService(
-                    settings.getUrl(),
-                    settings.getKey(Settings.USERNAME),
-                    settings.getKey(Settings.PASSWORD));
 
-            try {
-                if(service.addLink(url)) {
-                    result = true;
-                } else if(context != null) {
-                    errorMessage = context.getString(R.string.addLink_errorMessage);
+            String username = settings.getKey(Settings.USERNAME);
+            if(username != null && username.length() > 0) {
+                isOffline = false;
+
+                WallabagService service = new WallabagService(
+                        settings.getUrl(),
+                        username,
+                        settings.getKey(Settings.PASSWORD));
+
+                try {
+                    if(service.addLink(url)) {
+                        result = true;
+                    } else if(context != null) {
+                        errorMessage = context.getString(R.string.addLink_errorMessage);
+                    }
+                } catch (IOException e) {
+                    errorMessage = e.getMessage();
+                    e.printStackTrace();
                 }
-            } catch (IOException e) {
-                errorMessage = e.getMessage();
-                e.printStackTrace();
-            }
 
-            if(result) return true;
-        } else {
-            isOffline = true;
+                if(result) return true;
+            }
         }
 
         OfflineURLDao urlDao = DbConnection.getSession().getOfflineURLDao();

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/AddLinkTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/AddLinkTask.java
@@ -77,7 +77,7 @@ public class AddLinkTask extends AsyncTask<Void, Void, Boolean> {
         OfflineURLDao urlDao = DbConnection.getSession().getOfflineURLDao();
         OfflineURL offlineURL = new OfflineURL();
         offlineURL.setUrl(url);
-        urlDao.insert(offlineURL);
+        urlDao.insertOrReplace(offlineURL);
 
         savedOffline = true;
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/DeleteArticleTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/DeleteArticleTask.java
@@ -25,7 +25,7 @@ public class DeleteArticleTask extends GenericArticleTask {
 
     @Override
     protected Boolean doInBackgroundSimple(Void... params) throws IOException {
-        if(isOffline) return false;
+        if(isOffline || noCredentials) return false;
 
         if(service.deleteArticle(articleId)) return true;
 
@@ -37,11 +37,11 @@ public class DeleteArticleTask extends GenericArticleTask {
     protected void onPostExecute(Boolean success) {
         super.onPostExecute(success);
 
-        if(success || isOffline) {
+        if(success || isOffline || noCredentials) {
             if(context != null) {
                 Toast.makeText(context, R.string.deleteArticle_deleted, Toast.LENGTH_SHORT).show();
 
-                if(isOffline) {
+                if(isOffline && !noCredentials) {
                     Toast.makeText(context, R.string.deleteArticle_noInternetConnection,
                             Toast.LENGTH_SHORT).show();
                 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/GenericArticleTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/GenericArticleTask.java
@@ -27,6 +27,7 @@ public abstract class GenericArticleTask extends AsyncTask<Void, Void, Boolean> 
     protected WallabagService service;
     protected String errorMessage;
     protected boolean isOffline;
+    protected boolean noCredentials;
 
     public GenericArticleTask(Context context, int articleId, DaoSession daoSession) {
         this.context = context;
@@ -78,10 +79,14 @@ public abstract class GenericArticleTask extends AsyncTask<Void, Void, Boolean> 
     protected void prepareBG() {
         if(WallabagConnection.isNetworkOnline()) {
             Settings settings = App.getInstance().getSettings();
-            service = new WallabagService(
-                    settings.getUrl(),
-                    settings.getKey(Settings.USERNAME),
-                    settings.getKey(Settings.PASSWORD));
+            String username = settings.getKey(Settings.USERNAME);
+            noCredentials = username == null || username.length() == 0;
+            if(!noCredentials) {
+                service = new WallabagService(
+                        settings.getUrl(),
+                        username,
+                        settings.getKey(Settings.PASSWORD));
+            }
         } else {
             isOffline = true;
         }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/ToggleArchiveTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/ToggleArchiveTask.java
@@ -26,7 +26,7 @@ public class ToggleArchiveTask extends GenericArticleTask {
 
     @Override
     protected Boolean doInBackgroundSimple(Void... params) throws IOException {
-        if(isOffline) return false;
+        if(isOffline || noCredentials) return false;
 
         if(service.toggleArchive(articleId)) return true;
 
@@ -41,14 +41,14 @@ public class ToggleArchiveTask extends GenericArticleTask {
         article.setSync(success); // ?
         articleDao.update(article);
 
-        if(success || isOffline) {
+        if(success || isOffline || noCredentials) {
             if(context != null) {
                 Toast.makeText(context, article.getArchive()
                                 ? R.string.moved_to_archive_message
                                 : R.string.marked_as_unread_message,
                         Toast.LENGTH_SHORT).show();
 
-                if(isOffline) {
+                if(isOffline && !noCredentials) {
                     Toast.makeText(context, R.string.toggleArchive_noInternetConnection,
                             Toast.LENGTH_SHORT).show();
                 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/ToggleFavoriteTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/ToggleFavoriteTask.java
@@ -26,7 +26,7 @@ public class ToggleFavoriteTask extends GenericArticleTask {
 
     @Override
     protected Boolean doInBackgroundSimple(Void... params) throws IOException {
-        if(isOffline) return false;
+        if(isOffline || noCredentials) return false;
 
         if(service.toggleFavorite(articleId)) return true;
 
@@ -41,14 +41,14 @@ public class ToggleFavoriteTask extends GenericArticleTask {
         article.setSync(success); // ?
         articleDao.update(article);
 
-        if(success || isOffline) {
+        if(success || isOffline || noCredentials) {
             if(context != null) {
                 Toast.makeText(context, article.getFavorite()
                                 ? R.string.added_to_favorites_message
                                 : R.string.removed_from_favorites_message,
                         Toast.LENGTH_SHORT).show();
 
-                if(isOffline) {
+                if(isOffline && !noCredentials) {
                     Toast.makeText(context, R.string.toggleFavorite_noInternetConnection,
                             Toast.LENGTH_SHORT).show();
                 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
@@ -99,18 +99,35 @@ public class ArticlesListActivity extends AppCompatActivity
             firstTimeShown = false;
 
             WallabagSettings wallabagSettings = WallabagSettings.settingsFromDisk(settings);
-            if (!wallabagSettings.isValid()) {
-                AlertDialog.Builder messageBox = new AlertDialog.Builder(ArticlesListActivity.this);
+            if(!wallabagSettings.isValid()) {
+                AlertDialog.Builder messageBox = new AlertDialog.Builder(this);
                 messageBox.setTitle(R.string.firstRun_d_welcome);
                 messageBox.setMessage(R.string.firstRun_d_configure);
                 messageBox.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        startActivity(new Intent(getBaseContext(), SettingsActivity.class));
+                        startActivity(new Intent(ArticlesListActivity.this, SettingsActivity.class));
                     }
                 });
                 messageBox.setCancelable(false);
                 messageBox.create().show();
+            } else if(!settings.getBoolean(Settings.CONFIGURE_OPTIONAL_DIALOG_SHOWN, false)) {
+                settings.setBoolean(Settings.CONFIGURE_OPTIONAL_DIALOG_SHOWN, true);
+
+                String username = settings.getString(Settings.USERNAME, null);
+                if(username == null || username.length() == 0) {
+                    AlertDialog.Builder messageBox = new AlertDialog.Builder(this);
+                    messageBox.setTitle(R.string.firstRun_d_optionalSettings_title);
+                    messageBox.setMessage(R.string.firstRun_d_optionalSettings_message);
+                    messageBox.setPositiveButton(R.string.go_to_settings, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            startActivity(new Intent(ArticlesListActivity.this, SettingsActivity.class));
+                        }
+                    });
+                    messageBox.setNegativeButton(R.string.dismiss, null);
+                    messageBox.create().show();
+                }
             }
         }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/BagItProxyActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/BagItProxyActivity.java
@@ -1,6 +1,5 @@
 package fr.gaulupeau.apps.Poche.ui;
 
-import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -12,6 +11,7 @@ import android.util.Patterns;
 import java.util.regex.Matcher;
 
 import fr.gaulupeau.apps.InThePoche.R;
+import fr.gaulupeau.apps.Poche.data.Settings;
 import fr.gaulupeau.apps.Poche.network.tasks.AddLinkTask;
 
 public class BagItProxyActivity extends AppCompatActivity {
@@ -49,20 +49,14 @@ public class BagItProxyActivity extends AppCompatActivity {
             return;
         }
 
+        Settings settings = new Settings(this);
+        if(!settings.getBoolean(Settings.CONFIGURE_OPTIONAL_DIALOG_SHOWN, false)) {
+            startActivity(new Intent(this, ArticlesListActivity.class)); // FLAG_ACTIVITY_CLEAR_TOP and/or FLAG_ACTIVITY_NEW_TASK maybe?
+        }
+
         Log.d(TAG, "Bagging " + pageUrl);
 
-        ProgressDialog progressDialog = new ProgressDialog(this);
-        progressDialog.setMessage(getString(R.string.d_addingToWallabag_text));
-        progressDialog.setCanceledOnTouchOutside(false);
-        progressDialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
-            @Override
-            public void onDismiss(DialogInterface dialog) {
-                finish();
-            }
-        });
-        progressDialog.show();
-
-        new AddLinkTask(pageUrl, this, null, progressDialog).execute();
+        new AddLinkTask(pageUrl, this, null, null).execute();
     }
 
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2,8 +2,12 @@
 <resources>
     <string name="app_name">wallabag</string>
     <string name="label_name">В бэг!</string>
-    <string name="author">Alexander Inglessi</string>
-    <string name="instructions">с помощью wallabag вы можете сохранять веб-страницы для отложенного чтения. Для этого сначала откройте страницу в браузере, как обычно. Затем нажмите <i>Поделиться</i> и выберите <i>В бэг!</i>. \nВы увидите страницу входа в wallabag. \nГотово! \nБольше информации про wallabag здесь:\n http://www.wallabag.org</string>
+    <string name="author">
+GAULUPEAU Jonathan — 2013-2015
+\nVictor Häggqvist — 2015
+\nРусская локализация: Alexander Inglessi
+</string>
+    <string name="instructions">С помощью wallabag вы можете сохранять веб-страницы для отложенного чтения. Для этого сначала откройте страницу в браузере, как обычно. Затем нажмите <i>Поделиться</i> и выберите <i>В бэг!</i>. \nВы увидите страницу входа в wallabag. \nГотово! \nБольше информации про wallabag здесь:\n http://www.wallabag.org</string>
     <string name="btnDone">Сохранить</string>
     <string name="url_label">URL wallabag</string>
     <string name="url_help">Например:\n<i>https://wallabag.example.com</i>\n<i>https://www.example.com/wallabag</i>\n<i>https://framabag.org/u/имя-пользователя</i></string>
@@ -23,9 +27,9 @@
     <string name="menuOpenOriginal">Открыть первоисточник</string>
     <string name="menu_open_random_article">Случайная статья</string>
     <string name="menuUploadOfflineURLs">Выгрузить офлайновые URL</string>
-    <string name="menuWipeDb">Удалить базу данных</string>
+    <string name="menuWipeDb">Очистить базу данных</string>
     <string name="wipe_db_dialog_title">Удалить данные?</string>
-    <string name="wipe_db_dialog_message">"Вы уверены, что хотите удалить базу данных?"</string>
+    <string name="wipe_db_dialog_message">"Вы уверены, что хотите очистить базу данных?"</string>
     <string name="d_deleteArticle_title">Удалить статью?</string>
     <string name="d_deleteArticle_message">Вы уверены, что хотите удалить статью?</string>
     <string name="txtSyncDone">Синхронизация выполнена!</string>
@@ -56,9 +60,12 @@
     <string name="d_connectionFail_title">Ошибка соединения</string>
     <string name="d_bag_fail_title">Ошибка</string>
     <string name="d_bag_fail_text">В строке не найден URL:\n</string>
-    <string name="d_addingToWallabag_text">Добавление в бэг</string>
     <string name="firstRun_d_welcome">Добро пожаловать в wallabag</string>
     <string name="firstRun_d_configure">Пожалуйста, настройте приложение для работы с вашим сервером wallabag.</string>
+    <string name="firstRun_d_optionalSettings_message">Для того чтобы сохранять страницы через приложение (и отправлять локальные изменения обратно на сервер Wallabag), необходимо ввести имя пользователя и пароль в настройках.</string>
+    <string name="firstRun_d_optionalSettings_title">Обновите настройки</string>
+    <string name="go_to_settings">Перейти в настройки</string>
+    <string name="dismiss">Пропустить</string>
     <string name="open_original">"Открыть первоисточник: "</string>
     <string name="settings_optionalCredentials">Опциональные данные пользователя</string>
     <string name="settings_optionalCredentialsDesc">Обычно используются для выгрузки на сервер</string>
@@ -86,7 +93,7 @@
     <string name="testConnection_errorMessage5">Ошибка входа; проверьте параметры HTTP-авторизации. Код ошибки: %d</string>
     <string name="testConnection_errorMessage_unknown">Неизвестная ошибка. Код ошибки: %d</string>
     <string name="d_testConnection_success_title">Успешно</string>
-    <string name="d_connectionTest_success_text">Проверка соединения выполнена</string>
+    <string name="d_connectionTest_success_text">Проверка соединения успешно выполнена</string>
     <string name="d_testConnection_fail_title">Ошибка</string>
     <string name="toggleArchive_errorMessage">Невозможно синхронизоваться с сервером</string>
     <string name="toggleArchive_noInternetConnection">Невозможно синхронизоваться с сервером: нет интернет-соединения</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,10 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="d_addingToWallabag_text">Bagging page</string>
     <string name="firstRun_d_welcome">Welcome to wallabag</string>
     <string name="firstRun_d_configure">Please configure this app with your hosted wallabag to get started.</string>
+    <string name="firstRun_d_optionalSettings_title">Update settings</string>
+    <string name="firstRun_d_optionalSettings_message">In order to save pages from the app (and to sync local changes back to server) you need to fill in Wallabag username and password in settings.</string>
+    <string name="go_to_settings">Go to settings</string>
+    <string name="dismiss">Dismiss</string>
     <string name="open_original">"Open original: "</string>
     <string name="settings_optionalCredentials">Optional credentials</string>
     <string name="settings_optionalCredentialsDesc">Used mostly to be able to sync back to server</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,11 +59,10 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="d_connectionFail_title">Connection Failure</string>
     <string name="d_bag_fail_title">Fail</string>
     <string name="d_bag_fail_text">Couldn\'t find a URL in share string:\n</string>
-    <string name="d_addingToWallabag_text">Bagging page</string>
     <string name="firstRun_d_welcome">Welcome to wallabag</string>
     <string name="firstRun_d_configure">Please configure this app with your hosted wallabag to get started.</string>
     <string name="firstRun_d_optionalSettings_title">Update settings</string>
-    <string name="firstRun_d_optionalSettings_message">In order to save pages from the app (and to sync local changes back to server) you need to fill in Wallabag username and password in settings.</string>
+    <string name="firstRun_d_optionalSettings_message">In order to save pages from the app (and to send local changes back to server) you need to fill in Wallabag username and password in settings.</string>
     <string name="go_to_settings">Go to settings</string>
     <string name="dismiss">Dismiss</string>
     <string name="open_original">"Open original: "</string>


### PR DESCRIPTION
* Fix #155.
* Add a message box suggesting to input username and passwords on first launch (for users who updated the app from an old version and might not see new settings). Now that I think about it, maybe I should also do something with the other welcome dialog... Anyway, that's better than nothing for now.
* Redirect user from `BagItProxyActivity` to main activity in order to see the message box mentioned above (for users without username entered and for the first time only).
* Don't attempt sync back to server if username is empty (and don't show related errors).
* Update localization a bit.

The PR should also [partially] solve #154, #150.