### PR TITLE
Fix BagItProxyActivity

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
@@ -100,6 +100,8 @@ public class ArticlesListActivity extends AppCompatActivity
 
             WallabagSettings wallabagSettings = WallabagSettings.settingsFromDisk(settings);
             if(!wallabagSettings.isValid()) {
+                settings.setBoolean(Settings.CONFIGURE_OPTIONAL_DIALOG_SHOWN, true);
+
                 AlertDialog.Builder messageBox = new AlertDialog.Builder(this);
                 messageBox.setTitle(R.string.firstRun_d_welcome);
                 messageBox.setMessage(R.string.firstRun_d_configure);

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/BagItProxyActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/BagItProxyActivity.java
@@ -57,6 +57,8 @@ public class BagItProxyActivity extends AppCompatActivity {
         Log.d(TAG, "Bagging " + pageUrl);
 
         new AddLinkTask(pageUrl, this, null, null).execute();
+
+        finish();
     }
 
 }


### PR DESCRIPTION
Fix #166.
Also set CONFIGURE_OPTIONAL_DIALOG_SHOWN in one more place to fix unnecessary redirect from BagItProxyActivity.

BTW, do we need [that extra](https://github.com/wallabag/android-app/pull/164/files) `/values-en/strings.xml`? 