### PR TITLE
fix the v2 check for valid Wallabag instance

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -27,7 +27,7 @@ public class Settings {
     public static final String WALLABAG_VERSION = "wallabag_version";
     public static final String WALLABAG_LOGIN_FORM_V1 = "<form method=\"post\" action=\"?login\" name=\"loginform\">";
     public static final String WALLABAG_LOGOUT_LINK_V1 = "href=\"./?logout\"";
-    public static final String WALLABAG_LOGIN_FORM_V2 = "<form action=\"/login_check\" method=\"post\" name=\"loginform\">";
+    public static final String WALLABAG_LOGIN_FORM_V2 = "/login_check\" method=\"post\" name=\"loginform\">";
     public static final String WALLABAG_LOGOUT_LINK_V2 = "href=\"/logout\"";
 
     private SharedPreferences pref;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -28,7 +28,8 @@ public class Settings {
     public static final String WALLABAG_LOGIN_FORM_V1 = "<form method=\"post\" action=\"?login\" name=\"loginform\">";
     public static final String WALLABAG_LOGOUT_LINK_V1 = "href=\"./?logout\"";
     public static final String WALLABAG_LOGIN_FORM_V2 = "/login_check\" method=\"post\" name=\"loginform\">";
-    public static final String WALLABAG_LOGOUT_LINK_V2 = "href=\"/logout\"";
+    public static final String WALLABAG_LOGO_V2 = "alt=\"wallabag logo\" />";
+    public static final String WALLABAG_LOGOUT_LINK_V2 = "/logout\">";
 
     private SharedPreferences pref;
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagService.java
@@ -120,7 +120,7 @@ public class WallabagService {
             return -1;
         }
 
-        if (body.contains(Settings.WALLABAG_LOGOUT_LINK_V2)) {
+        if (body.contains(Settings.WALLABAG_LOGOUT_LINK_V2) && body.contains(Settings.WALLABAG_LOGO_V2)) {
             Log.d(TAG, "guessWallabagVersion() already logged in, found Wallabag v2");
             wallabagVersion = 2;
         }
@@ -129,7 +129,7 @@ public class WallabagService {
             wallabagVersion = 1;
         }
 
-        if (body.contains(Settings.WALLABAG_LOGIN_FORM_V2)) {
+        if (body.contains(Settings.WALLABAG_LOGIN_FORM_V2) && body.contains(Settings.WALLABAG_LOGO_V2)) {
             Log.d(TAG, "guessWallabagVersion() found Wallabag v2");
             wallabagVersion = 2;
         }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
@@ -90,13 +90,11 @@ public class WallabagServiceEndpointV2 extends WallabagServiceEndpoint {
 
     protected boolean isLoginPage(String body) throws IOException {
         if(body == null || body.length() == 0) return false;
-
-//        "<body class=\"login\">"
-        return body.contains(Settings.WALLABAG_LOGIN_FORM_V2); // any way to improve?
+        return body.contains(Settings.WALLABAG_LOGIN_FORM_V2) && body.contains(Settings.WALLABAG_LOGO_V2);
     }
 
     protected boolean isRegularPage(String body) throws IOException {
-        return isRegularPage(body, Settings.WALLABAG_LOGOUT_LINK_V2);
+        return isRegularPage(body, Settings.WALLABAG_LOGOUT_LINK_V2) && isRegularPage(body, Settings.WALLABAG_LOGO_V2);
     }
 
     protected Request getLoginRequest(String csrfToken) throws IOException {


### PR DESCRIPTION
This PR fixes a problem reported in https://github.com/wallabag/android-app/issues/203#issuecomment-210520327

The problem occurs when Wallabag v2 is not installed to / path of the
webserver, but in a subdirectory, e.g. wallabag/. Our regex check for
a validwallabag instance does not work anymore. Therefore the regex has
been shortened in the beginning.