### PR TITLE
App widget unread article count

### DIFF
--- a/app/src-gen/fr/gaulupeau/apps/Poche/entity/ArticleDao.java
+++ b/app/src-gen/fr/gaulupeau/apps/Poche/entity/ArticleDao.java
@@ -1,6 +1,7 @@
 package fr.gaulupeau.apps.Poche.entity;
 
 import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 
@@ -192,5 +193,8 @@ public class ArticleDao extends AbstractDao<Article, Long> {
     protected boolean isEntityUpdateable() {
         return true;
     }
-    
+
+    public long getUnreadCount(SQLiteDatabase db) {
+        return DatabaseUtils.queryNumEntries(db, "ARTICLE", "favorite=0 AND archive=0");
+    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:installLocation="auto"
-    package="fr.gaulupeau.apps.InThePoche">
+    package="fr.gaulupeau.apps.InThePoche"
+    android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -16,6 +16,7 @@
         <activity android:name="fr.gaulupeau.apps.Poche.ui.ArticlesListActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -38,7 +39,7 @@
         </activity>
         <activity
             android:name="fr.gaulupeau.apps.Poche.ui.AddActivity"
-            android:label="@string/activity_add_label"/>
+            android:label="@string/activity_add_label" />
         <activity
             android:name="fr.gaulupeau.apps.Poche.ui.DialogHelperActivity"
             android:theme="@style/ProxyTheme"
@@ -55,6 +56,15 @@
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
         </service>
+        <receiver android:name="fr.gaulupeau.apps.Poche.ui.IconUnreadWidget">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/icon_unread_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -33,6 +33,7 @@ public class Settings {
     public static final String TTS_VOICE = "tts.voice";
     public static final String TTS_LANGUAGE_VOICE = "tts.language_voice:";
     public static final String TTS_AUTOPLAY_NEXT = "tts.autoplay_next";
+    public static final int WALLABAG_WIDGET_MAX_UNREAD_COUNT = 999;
 
     private SharedPreferences pref;
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/DeleteArticleTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/DeleteArticleTask.java
@@ -9,6 +9,7 @@ import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.entity.Article;
 import fr.gaulupeau.apps.Poche.entity.ArticleDao;
 import fr.gaulupeau.apps.Poche.ui.DialogHelperActivity;
+import fr.gaulupeau.apps.Poche.ui.IconUnreadWidget;
 
 public class DeleteArticleTask extends GenericArticleTask {
 
@@ -45,6 +46,7 @@ public class DeleteArticleTask extends GenericArticleTask {
                     Toast.makeText(context, R.string.deleteArticle_noInternetConnection,
                             Toast.LENGTH_SHORT).show();
                 }
+                IconUnreadWidget.triggerWidgetUpdate(context);
             }
         } else {
             if(context != null) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/ToggleArchiveTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/ToggleArchiveTask.java
@@ -9,6 +9,7 @@ import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.entity.Article;
 import fr.gaulupeau.apps.Poche.entity.ArticleDao;
 import fr.gaulupeau.apps.Poche.ui.DialogHelperActivity;
+import fr.gaulupeau.apps.Poche.ui.IconUnreadWidget;
 
 public class ToggleArchiveTask extends GenericArticleTask {
 
@@ -52,6 +53,7 @@ public class ToggleArchiveTask extends GenericArticleTask {
                     Toast.makeText(context, R.string.toggleArchive_noInternetConnection,
                             Toast.LENGTH_SHORT).show();
                 }
+                IconUnreadWidget.triggerWidgetUpdate(context);
             }
         } else {
             if(context != null) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/UpdateFeedTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/UpdateFeedTask.java
@@ -27,6 +27,7 @@ import fr.gaulupeau.apps.Poche.data.DbConnection;
 import fr.gaulupeau.apps.Poche.network.WallabagConnection;
 import fr.gaulupeau.apps.Poche.entity.Article;
 import fr.gaulupeau.apps.Poche.entity.ArticleDao;
+import fr.gaulupeau.apps.Poche.ui.IconUnreadWidget;
 
 public class UpdateFeedTask extends AsyncTask<Void, Void, Void> {
 
@@ -210,6 +211,8 @@ public class UpdateFeedTask extends AsyncTask<Void, Void, Void> {
                 errorMessage = App.getInstance().getString(R.string.feedUpdater_feedProcessingError);
                 return false;
             }
+
+            IconUnreadWidget.triggerWidgetUpdate(App.getInstance().getApplicationContext());
 
             Log.d(TAG, "updateByFeed() finished successfully");
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/IconUnreadWidget.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/IconUnreadWidget.java
@@ -3,22 +3,48 @@ package fr.gaulupeau.apps.Poche.ui;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
 import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+import android.view.View;
 import android.widget.RemoteViews;
 
 import fr.gaulupeau.apps.InThePoche.R;
+import fr.gaulupeau.apps.Poche.data.DbConnection;
+import fr.gaulupeau.apps.Poche.data.Settings;
+import fr.gaulupeau.apps.Poche.entity.ArticleDao;
 
 /**
  * Implementation of App Widget functionality.
  */
 public class IconUnreadWidget extends AppWidgetProvider {
+    private static final String TAG = IconUnreadWidget.class.getSimpleName();
 
     static void updateAppWidget(Context context, AppWidgetManager appWidgetManager,
                                 int appWidgetId) {
+        Log.d(TAG, "updateAppWidget() appWidgetId=" + appWidgetId);
 
-        CharSequence widgetText = context.getString(R.string.appwidget_text);
+
+        ArticleDao articleDao = DbConnection.getSession().getArticleDao();
+        long unreadCount = articleDao.getUnreadCount(articleDao.getDatabase());
+        Log.d(TAG, "updateAppWidget() read from database unreadCount=" + unreadCount);
+
         // Construct the RemoteViews object
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.icon_unread);
-        views.setTextViewText(R.id.appwidget_text, widgetText);
+        Log.d(TAG, "updateAppWidget() setting unread_count_text to " + unreadCount);
+
+        if (unreadCount <= 0) {
+            // Hide TextView for unread count if there are no unread messages.
+            views.setViewVisibility(R.id.unread_count_text, View.GONE);
+        } else {
+            views.setViewVisibility(R.id.unread_count_text, View.VISIBLE);
+            if (unreadCount > Settings.WALLABAG_WIDGET_MAX_UNREAD_COUNT) {
+                views.setTextViewText(R.id.unread_count_text, Settings.WALLABAG_WIDGET_MAX_UNREAD_COUNT + "+");
+            } else {
+                views.setTextViewText(R.id.unread_count_text, "" + unreadCount);
+            }
+        }
+
+        //views.setOnClickPendingIntent(R.id., getRefreshPendingIntent(context, appWidgetId));
 
         // Instruct the widget manager to update the widget
         appWidgetManager.updateAppWidget(appWidgetId, views);
@@ -26,6 +52,7 @@ public class IconUnreadWidget extends AppWidgetProvider {
 
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+        Log.d(TAG, "onUpdate() appWidgetIds.length=" + appWidgetIds.length);
         // There may be multiple widgets active, so update all of them
         for (int appWidgetId : appWidgetIds) {
             updateAppWidget(context, appWidgetManager, appWidgetId);
@@ -34,12 +61,29 @@ public class IconUnreadWidget extends AppWidgetProvider {
 
     @Override
     public void onEnabled(Context context) {
+        Log.d(TAG, "onEnabled()");
         // Enter relevant functionality for when the first widget is created
     }
 
     @Override
     public void onDisabled(Context context) {
+        Log.d(TAG, "onDisabled()");
         // Enter relevant functionality for when the last widget is disabled
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent)
+    {
+        Log.d(TAG, "onReceive()");
+        final String action = intent.getAction();
+        Log.d(TAG, "onReceive() action=" + action);
+
+        if (intent.getAction().equals("android.appwidget.action.APPWIDGET_UPDATE")) {
+            Log.d(TAG, "onReceive() some code here that will update your widget");
+            //some code here that will update your widget
+        }
+
+        super.onReceive(context, intent);
     }
 }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/IconUnreadWidget.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/IconUnreadWidget.java
@@ -1,0 +1,45 @@
+package fr.gaulupeau.apps.Poche.ui;
+
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.Context;
+import android.widget.RemoteViews;
+
+import fr.gaulupeau.apps.InThePoche.R;
+
+/**
+ * Implementation of App Widget functionality.
+ */
+public class IconUnreadWidget extends AppWidgetProvider {
+
+    static void updateAppWidget(Context context, AppWidgetManager appWidgetManager,
+                                int appWidgetId) {
+
+        CharSequence widgetText = context.getString(R.string.appwidget_text);
+        // Construct the RemoteViews object
+        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.icon_unread);
+        views.setTextViewText(R.id.appwidget_text, widgetText);
+
+        // Instruct the widget manager to update the widget
+        appWidgetManager.updateAppWidget(appWidgetId, views);
+    }
+
+    @Override
+    public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+        // There may be multiple widgets active, so update all of them
+        for (int appWidgetId : appWidgetIds) {
+            updateAppWidget(context, appWidgetManager, appWidgetId);
+        }
+    }
+
+    @Override
+    public void onEnabled(Context context) {
+        // Enter relevant functionality for when the first widget is created
+    }
+
+    @Override
+    public void onDisabled(Context context) {
+        // Enter relevant functionality for when the last widget is disabled
+    }
+}
+

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/IconUnreadWidget.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/IconUnreadWidget.java
@@ -1,5 +1,6 @@
 package fr.gaulupeau.apps.Poche.ui;
 
+import android.app.PendingIntent;
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
 import android.content.ComponentName;
@@ -45,7 +46,12 @@ public class IconUnreadWidget extends AppWidgetProvider {
             }
         }
 
-        //views.setOnClickPendingIntent(R.id., getRefreshPendingIntent(context, appWidgetId));
+        // start article list activity on click on the widget
+        Intent intent = new Intent(context, ArticlesListActivity.class);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, appWidgetId, intent, 0);
+        views.setOnClickPendingIntent(R.id.icon_unread_layout, pendingIntent);
 
         // Instruct the widget manager to update the widget
         appWidgetManager.updateAppWidget(appWidgetId, views);
@@ -58,33 +64,6 @@ public class IconUnreadWidget extends AppWidgetProvider {
         for (int appWidgetId : appWidgetIds) {
             updateAppWidget(context, appWidgetManager, appWidgetId);
         }
-    }
-
-    @Override
-    public void onEnabled(Context context) {
-        Log.d(TAG, "onEnabled()");
-        // Enter relevant functionality for when the first widget is created
-    }
-
-    @Override
-    public void onDisabled(Context context) {
-        Log.d(TAG, "onDisabled()");
-        // Enter relevant functionality for when the last widget is disabled
-    }
-
-    @Override
-    public void onReceive(Context context, Intent intent)
-    {
-        Log.d(TAG, "onReceive()");
-        final String action = intent.getAction();
-        Log.d(TAG, "onReceive() action=" + action);
-
-        if (intent.getAction().equals("android.appwidget.action.APPWIDGET_UPDATE")) {
-            Log.d(TAG, "onReceive() some code here that will update your widget");
-            //some code here that will update your widget
-        }
-
-        super.onReceive(context, intent);
     }
 
     public static void triggerWidgetUpdate(Context context) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/IconUnreadWidget.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/IconUnreadWidget.java
@@ -2,6 +2,7 @@ package fr.gaulupeau.apps.Poche.ui;
 
 import android.appwidget.AppWidgetManager;
 import android.appwidget.AppWidgetProvider;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
@@ -85,5 +86,16 @@ public class IconUnreadWidget extends AppWidgetProvider {
 
         super.onReceive(context, intent);
     }
-}
 
+    public static void triggerWidgetUpdate(Context context) {
+        Log.d(TAG, "static triggerWidgetUpdate()");
+        Context appContext = context.getApplicationContext();
+        AppWidgetManager appWidgetManager = AppWidgetManager.getInstance(appContext);
+        ComponentName thisWidget = new ComponentName(appContext, IconUnreadWidget.class);
+        int[] widgetIds = appWidgetManager.getAppWidgetIds(thisWidget);
+        Intent intent = new Intent(context, IconUnreadWidget.class);
+        intent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds);
+        context.sendBroadcast(intent);
+    }
+}

--- a/app/src/main/res/drawable/rounded_rectangle_shape.xml
+++ b/app/src/main/res/drawable/rounded_rectangle_shape.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+android:shape="rectangle" >
+
+    <solid android:color="#c70000" />
+
+    <stroke
+        android:width="1px"
+        android:color="#000" />
+
+    <corners
+    android:bottomLeftRadius="10dp"
+    android:bottomRightRadius="10dp"
+    android:topLeftRadius="10dp"
+    android:topRightRadius="10dp" />
+
+</shape>

--- a/app/src/main/res/layout/icon_unread.xml
+++ b/app/src/main/res/layout/icon_unread.xml
@@ -1,0 +1,21 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#09C"
+    android:padding="@dimen/widget_margin">
+
+    <TextView
+        android:id="@+id/appwidget_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:layout_margin="8dp"
+        android:background="#09C"
+        android:contentDescription="@string/appwidget_text"
+        android:text="@string/appwidget_text"
+        android:textColor="#ffffff"
+        android:textSize="24sp"
+        android:textStyle="bold|italic" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/icon_unread.xml
+++ b/app/src/main/res/layout/icon_unread.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:gravity="center"
     android:clickable="true"
     android:focusable="true"
     >

--- a/app/src/main/res/layout/icon_unread.xml
+++ b/app/src/main/res/layout/icon_unread.xml
@@ -1,21 +1,48 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/icon_unread_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#09C"
-    android:padding="@dimen/widget_margin">
-
-    <TextView
-        android:id="@+id/appwidget_text"
+    android:orientation="vertical"
+    android:clickable="true"
+    android:focusable="true"
+    >
+    <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true"
-        android:layout_margin="8dp"
-        android:background="#09C"
-        android:contentDescription="@string/appwidget_text"
-        android:text="@string/appwidget_text"
-        android:textColor="#ffffff"
-        android:textSize="24sp"
-        android:textStyle="bold|italic" />
+        android:layout_gravity="center">
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:scaleType="fitCenter"
+            android:src="@drawable/icon"
+            android:contentDescription="@string/app_name"
+            android:layout_gravity="center" />
 
-</RelativeLayout>
+        <TextView
+            android:id="@+id/unread_count_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right|bottom"
+            android:paddingTop="0.5dp"
+            android:paddingBottom="0.5dp"
+            android:paddingLeft="5dp"
+            android:paddingRight="5dp"
+            android:textSize="12sp"
+            android:visibility="gone"
+            android:background="@drawable/rounded_rectangle_shape"
+            android:textColor="#ffffff" />
+    </FrameLayout>
+    <TextView
+        android:id="@+id/unread_count_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="0dp"
+        android:textSize="12sp"
+        android:text="@string/app_name"
+        android:layout_gravity="center_horizontal"
+        android:shadowColor="#000000"
+        android:shadowDy="1"
+        android:shadowRadius="4"
+        android:singleLine="true"
+        android:textColor="#ffffff" />
+</LinearLayout>

--- a/app/src/main/res/values-v14/dimens.xml
+++ b/app/src/main/res/values-v14/dimens.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--
+Refer to App Widget Documentation for margin information
+http://developer.android.com/guide/topics/appwidgets/index.html#CreatingLayout
+    -->
+    <dimen name="widget_margin">0dp</dimen>
+
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,4 +4,10 @@
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
+
+    <!--
+Refer to App Widget Documentation for margin information
+http://developer.android.com/guide/topics/appwidgets/index.html#CreatingLayout
+    -->
+    <dimen name="widget_margin">8dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,4 +158,5 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="readSpeed">Read speed</string>
     <string name="voiceHeight">Voice height</string>
     <string name="readVolume">Read volume</string>
+    <string name="add_widget">Add widget</string>
 </resources>

--- a/app/src/main/res/xml/icon_unread_info.xml
+++ b/app/src/main/res/xml/icon_unread_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialKeyguardLayout="@layout/icon_unread"
+    android:initialLayout="@layout/icon_unread"
+    android:minHeight="40dp"
+    android:minWidth="40dp"
+    android:previewImage="@drawable/icon"
+    android:updatePeriodMillis="86400000"
+    android:widgetCategory="home_screen"></appwidget-provider>


### PR DESCRIPTION
I created a widget which shows how many articles are saved in the Wallabag database of your Android app, which are unread. So if you are limiting the RSS feed in your Wallabag v2 (rss feed limit < no. unread articles), you will only see that limit and not the real unread count you see in the web browser.

![screenshot.png](https://i.imgur.com/uHDUAMu.png)

features of the widget:
- on click start the application
- trigger widget counter update on sync, archive or delete action in Wallabag app

_Thanks to K-9 Mail for inspiration._
