### PR TITLE
guessWallabagVersion() makes use of /api for v2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "fr.gaulupeau.apps.InThePoche"
-        minSdkVersion 8
+        minSdkVersion 9
         targetSdkVersion 23
         versionCode 23
         versionName "1.9.9.2"


### PR DESCRIPTION
Refactores guessWallabagVersion() into several methods having just one
task. The isWallabagVersion2() makes use of the provided API which was
introduced since v2.
Needed to increase minSdkVersion for isEmpty() check on Strings. (When some day the Widget PR will be merged, the minSdkVersion is increased anyway.)