### PR TITLE
Fixes getCredentials() if Wbg installed in subdir

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
@@ -80,7 +80,11 @@ public class WallabagServiceEndpointV2 extends WallabagServiceEndpoint {
     }
 
     public FeedsCredentials getCredentials() throws IOException {
-        return getCredentials("/config", "\"/(\\S+)/([a-zA-Z0-9]+)/unread.xml\"");
+        FeedsCredentials fc = getCredentials("/config", "\"/(\\S+)/([a-zA-Z0-9]+)/unread.xml\"");
+        // overwrite userID with username because first matcher group of previous regex, which
+        // should return the user name, might include the subdirectory in which wallabag is installed
+        fc.userID = username;
+        return fc;
     }
 
 


### PR DESCRIPTION
This commit fixes the problem with requesting the FeedsCredentials when
Wallabag v2 is installed in a subdirectory of the server e.g.
endpoint=http://server/wbg/. This is done with a check of the userID for
a slash. In the given example the userID would have been "wbg/user". Now, if a slash is found, only the string right of the slash ("user") is used as userID.

Hopefully a user name never contains a slash ;)