### PR TITLE
Fixes #218 Titles show encoding problems

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/UpdateFeedTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/UpdateFeedTask.java
@@ -2,6 +2,7 @@ package fr.gaulupeau.apps.Poche.network.tasks;
 
 import android.database.sqlite.SQLiteDatabase;
 import android.os.AsyncTask;
+import android.text.Html;
 import android.util.Log;
 import android.util.Xml;
 
@@ -312,7 +313,7 @@ public class UpdateFeedTask extends AsyncTask<Void, Void, Void> {
                         existing = false;
                     }
 
-                    article.setTitle(item.title);
+                    article.setTitle(Html.fromHtml(item.title).toString());
                     article.setContent(item.description);
                     article.setUrl(item.link);
                     article.setArticleId(id);


### PR DESCRIPTION
This commit fixes #218, where a title of an article was html encoded.
Now the title is html decoded before storing it as article with the help
of the method Html.fromHtml()

E.g. before:
`Using Let&#039;s Encrypt with Kerio Connect`
Now is saved:
`Using Let's Encrypt with Kerio Connect`
