### PR TITLE
Fixes #224 NullPointerException: Attempt to invoke virtual method

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/UpdateFeedTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/UpdateFeedTask.java
@@ -343,6 +343,7 @@ public class UpdateFeedTask extends AsyncTask<Void, Void, Void> {
                     Article article = articleDao.queryBuilder()
                             .where(ArticleDao.Properties.ArticleId.eq(id))
                             .build().unique();
+                    if(article == null) continue;
 
                     if(article.getFavorite() != null && article.getFavorite()) continue;
 


### PR DESCRIPTION
'java.lang.Boolean fr.gaulupeau.apps.Poche.entity.Article.getFavorite()'
on a null object

To avoid the NullPointerException, we skip one loop cycle if we get null
instead of an article with a special id from the ArticleDao.