### PR TITLE
Refactoring

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -25,11 +25,6 @@ public class Settings {
     public static final String THEME = "theme";
     public static final String CONFIGURE_OPTIONAL_DIALOG_SHOWN = "configure_optional_dialog_shown";
     public static final String WALLABAG_VERSION = "wallabag_version";
-    public static final String WALLABAG_LOGIN_FORM_V1 = "<form method=\"post\" action=\"?login\" name=\"loginform\">";
-    public static final String WALLABAG_LOGOUT_LINK_V1 = "href=\"./?logout\"";
-    public static final String WALLABAG_LOGIN_FORM_V2 = "/login_check\" method=\"post\" name=\"loginform\">";
-    public static final String WALLABAG_LOGO_V2 = "alt=\"wallabag logo\" />";
-    public static final String WALLABAG_LOGOUT_LINK_V2 = "/logout\">";
     public static final String TTS_VISIBLE = "tts.visible";
     public static final String TTS_OPTIONS_VISIBLE = "tts.options.visible";
     public static final String TTS_SPEED = "tts.speed";

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagService.java
@@ -14,6 +14,8 @@ import fr.gaulupeau.apps.Poche.data.FeedsCredentials;
 import fr.gaulupeau.apps.Poche.data.Settings;
 
 import static fr.gaulupeau.apps.Poche.network.WallabagConnection.getRequest;
+import static fr.gaulupeau.apps.Poche.network.WallabagServiceEndpointV1.WALLABAG_LOGIN_FORM_V1;
+import static fr.gaulupeau.apps.Poche.network.WallabagServiceEndpointV1.WALLABAG_LOGOUT_LINK_V1;
 
 /**
  * @author Victor Häggqvist
@@ -124,7 +126,7 @@ public class WallabagService {
         String body = getBodyFromHttpResponse(endpoint + "/?view=about");
         if (body != null
                 && !body.isEmpty()
-                && (body.contains(Settings.WALLABAG_LOGOUT_LINK_V1) || body.contains(Settings.WALLABAG_LOGIN_FORM_V1))
+                && (body.contains(WALLABAG_LOGOUT_LINK_V1) || body.contains(WALLABAG_LOGIN_FORM_V1))
                 ) {
             Log.d(TAG, "isWallabagVersion1() found Wallabag v1");
             return true;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpoint.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpoint.java
@@ -118,8 +118,8 @@ public abstract class WallabagServiceEndpoint {
 
     protected abstract boolean isRegularPage(String body) throws IOException;
 
-    protected boolean isRegularPage(String body, String logoutLink) throws IOException {
-        return !(body == null || body.length() == 0) && body.contains(logoutLink);
+    protected boolean containsMarker(String body, String marker) throws IOException {
+        return !(body == null || body.isEmpty()) && body.contains(marker);
     }
 
     protected abstract Request getLoginRequest(String csrfToken) throws IOException;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV1.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV1.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.App;
 import fr.gaulupeau.apps.Poche.data.FeedsCredentials;
-import fr.gaulupeau.apps.Poche.data.Settings;
 
 import static fr.gaulupeau.apps.Poche.network.WallabagConnection.getHttpURL;
 import static fr.gaulupeau.apps.Poche.network.WallabagConnection.getRequest;
@@ -24,6 +23,10 @@ import static fr.gaulupeau.apps.Poche.network.WallabagConnection.getRequestBuild
  * Created by strubbl on 11.04.16.
  */
 public class WallabagServiceEndpointV1 extends WallabagServiceEndpoint {
+
+    public static final String WALLABAG_LOGIN_FORM_V1 = "<form method=\"post\" action=\"?login\" name=\"loginform\">";
+    public static final String WALLABAG_LOGOUT_LINK_V1 = "href=\"./?logout\"";
+
     private static final String TAG = WallabagServiceEndpointV1.class.getSimpleName();
 
     public WallabagServiceEndpointV1(String endpoint, String username, String password, OkHttpClient client) {
@@ -84,11 +87,11 @@ public class WallabagServiceEndpointV1 extends WallabagServiceEndpoint {
     }
 
     protected boolean isLoginPage(String body) throws IOException {
-        return !(body == null || body.length() == 0) && body.contains(Settings.WALLABAG_LOGIN_FORM_V1);
+        return !(body == null || body.length() == 0) && body.contains(WALLABAG_LOGIN_FORM_V1);
     }
 
     protected boolean isRegularPage(String body) throws IOException {
-        return isRegularPage(body, Settings.WALLABAG_LOGOUT_LINK_V1);
+        return isRegularPage(body, WALLABAG_LOGOUT_LINK_V1);
     }
 
     private Request getLoginRequest() throws IOException {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV1.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV1.java
@@ -95,10 +95,10 @@ public class WallabagServiceEndpointV1 extends WallabagServiceEndpoint {
     }
 
     private Request getLoginRequest() throws IOException {
-        return getLoginRequest("");
+        return getLoginRequest(null);
     }
 
-    protected Request getLoginRequest(String csrfToken) throws IOException {
+    protected Request getLoginRequest(String unused) throws IOException {
         HttpUrl url = getHttpURL(endpoint + "/?login");
 
         // TODO: maybe move null checks somewhere else

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV1.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV1.java
@@ -27,12 +27,13 @@ public class WallabagServiceEndpointV1 extends WallabagServiceEndpoint {
     public static final String WALLABAG_LOGIN_FORM_V1 = "<form method=\"post\" action=\"?login\" name=\"loginform\">";
     public static final String WALLABAG_LOGOUT_LINK_V1 = "href=\"./?logout\"";
 
+    private static final String CREDENTIALS_PATTERN = "\"\\?feed&amp;type=home&amp;user_id=(\\d+)&amp;token=([a-zA-Z0-9]+)\"";
+
     private static final String TAG = WallabagServiceEndpointV1.class.getSimpleName();
 
     public WallabagServiceEndpointV1(String endpoint, String username, String password, OkHttpClient client) {
         super(endpoint, username, password, client);
     }
-
 
     public int testConnection() throws IOException {
         // TODO: detect redirects
@@ -83,7 +84,7 @@ public class WallabagServiceEndpointV1 extends WallabagServiceEndpoint {
     }
 
     public FeedsCredentials getCredentials() throws IOException {
-        return getCredentials("/?view=config", "\"\\?feed&amp;type=home&amp;user_id=(\\d+)&amp;token=([a-zA-Z0-9]+)\"");
+        return getCredentials("/?view=config", CREDENTIALS_PATTERN);
     }
 
     protected boolean isLoginPage(String body) throws IOException {
@@ -91,7 +92,7 @@ public class WallabagServiceEndpointV1 extends WallabagServiceEndpoint {
     }
 
     protected boolean isRegularPage(String body) throws IOException {
-        return isRegularPage(body, WALLABAG_LOGOUT_LINK_V1);
+        return containsMarker(body, WALLABAG_LOGOUT_LINK_V1);
     }
 
     private Request getLoginRequest() throws IOException {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
@@ -178,14 +178,27 @@ public class WallabagServiceEndpointV2 extends WallabagServiceEndpoint {
 
     private String getCsrfToken(String body) {
         String startCsrfTokenString = "<input type=\"hidden\" name=\"_csrf_token\" value=\"";
-        int csrfTokenStartIndex = body.indexOf(startCsrfTokenString) + startCsrfTokenString.length();
-        int csrfTokenEndIndex = body.indexOf("\" />", csrfTokenStartIndex);
-        Log.d(TAG, "getCsrfToken() csrfTokenStartIndex=" + csrfTokenStartIndex + " and csrfTokenEndIndex=" + csrfTokenEndIndex + ", so csrfTokenLength=" + (csrfTokenEndIndex-csrfTokenStartIndex));
-        if(csrfTokenStartIndex==-1 || csrfTokenEndIndex==-1){
-            return null; // cannot find csrf string in the login page
+
+        int csrfTokenStartIndex = body.indexOf(startCsrfTokenString);
+        if(csrfTokenStartIndex == -1) {
+            Log.d(TAG, "getCsrfToken() can't find start");
+            return null;
         }
+        csrfTokenStartIndex += startCsrfTokenString.length();
+
+        int csrfTokenEndIndex = body.indexOf("\" />", csrfTokenStartIndex);
+        if(csrfTokenEndIndex == -1) {
+            Log.d(TAG, "getCsrfToken() can't find end");
+            return null;
+        }
+
+        Log.d(TAG, "getCsrfToken() csrfTokenStartIndex=" + csrfTokenStartIndex
+                + " and csrfTokenEndIndex=" + csrfTokenEndIndex
+                + ", so csrfTokenLength=" + (csrfTokenEndIndex - csrfTokenStartIndex));
+
         String csrfToken = body.substring(csrfTokenStartIndex, csrfTokenEndIndex);
         Log.d(TAG, "getCsrfToken() csrfToken=" + csrfToken);
+
         return csrfToken;
     }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.App;
 import fr.gaulupeau.apps.Poche.data.FeedsCredentials;
-import fr.gaulupeau.apps.Poche.data.Settings;
 
 import static fr.gaulupeau.apps.Poche.network.WallabagConnection.getHttpURL;
 import static fr.gaulupeau.apps.Poche.network.WallabagConnection.getRequest;
@@ -24,6 +23,11 @@ import static fr.gaulupeau.apps.Poche.network.WallabagConnection.getRequestBuild
  * Created by strubbl on 11.04.16.
  */
 public class WallabagServiceEndpointV2 extends WallabagServiceEndpoint {
+
+    public static final String WALLABAG_LOGIN_FORM_V2 = "/login_check\" method=\"post\" name=\"loginform\">";
+    public static final String WALLABAG_LOGOUT_LINK_V2 = "/logout\">";
+    public static final String WALLABAG_LOGO_V2 = "alt=\"wallabag logo\" />";
+
     private static final String TAG = WallabagServiceEndpointV2.class.getSimpleName();
 
     public int testConnection() throws IOException {
@@ -93,11 +97,11 @@ public class WallabagServiceEndpointV2 extends WallabagServiceEndpoint {
     }
 
     protected boolean isLoginPage(String body) throws IOException {
-        return !(body == null || body.length() == 0) && body.contains(Settings.WALLABAG_LOGIN_FORM_V2) && body.contains(Settings.WALLABAG_LOGO_V2);
+        return !(body == null || body.length() == 0) && body.contains(WALLABAG_LOGIN_FORM_V2) && body.contains(WALLABAG_LOGO_V2);
     }
 
     protected boolean isRegularPage(String body) throws IOException {
-        return isRegularPage(body, Settings.WALLABAG_LOGOUT_LINK_V2) && isRegularPage(body, Settings.WALLABAG_LOGO_V2);
+        return isRegularPage(body, WALLABAG_LOGOUT_LINK_V2) && isRegularPage(body, WALLABAG_LOGO_V2);
     }
 
     protected Request getLoginRequest(String csrfToken) throws IOException {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/GetCredentialsTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/GetCredentialsTask.java
@@ -1,44 +1,36 @@
 package fr.gaulupeau.apps.Poche.network.tasks;
 
-import android.app.ProgressDialog;
-import android.content.Context;
 import android.os.AsyncTask;
-import android.widget.EditText;
-import android.widget.Toast;
 
 import java.io.IOException;
 
-import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.data.FeedsCredentials;
 import fr.gaulupeau.apps.Poche.network.WallabagService;
 
 public class GetCredentialsTask extends AsyncTask<Void, Void, Boolean> {
 
-    private Context context;
+    private ResultHandler handler;
     private final String endpoint;
     private final String username;
     private final String password;
-    private EditText userId;
-    private EditText token;
-    private ProgressDialog progressDialog;
-    private FeedsCredentials credentials;
 
-    public GetCredentialsTask(Context context, String endpoint, String username, String password,
-                              EditText userId, EditText token, ProgressDialog progressDialog) {
-        this.context = context;
+    private FeedsCredentials credentials;
+    private int wallabagVersion = -1;
+
+    public GetCredentialsTask(ResultHandler handler, String endpoint,
+                              String username, String password) {
+        this.handler = handler;
         this.endpoint = endpoint;
         this.username = username;
         this.password = password;
-        this.userId = userId;
-        this.token = token;
-        this.progressDialog = progressDialog;
     }
 
     @Override
     protected Boolean doInBackground(Void... params) {
-        WallabagService service = new WallabagService(endpoint, username, password);
+        WallabagService service = new WallabagService(endpoint, username, password, -1);
         try {
             credentials = service.getCredentials();
+            wallabagVersion = service.getWallabagVersion();
 
             return credentials != null;
         } catch (IOException e) {
@@ -49,18 +41,17 @@ public class GetCredentialsTask extends AsyncTask<Void, Void, Boolean> {
 
     @Override
     protected void onPostExecute(Boolean success) {
-        if(progressDialog != null) progressDialog.dismiss();
-
-        if (success) {
-            userId.setText(credentials.userID);
-            token.setText(credentials.token);
-
-            if(context != null)
-                Toast.makeText(context, R.string.getCredentials_success, Toast.LENGTH_SHORT).show();
-        } else {
-            if(context != null)
-                Toast.makeText(context, R.string.getCredentials_fail, Toast.LENGTH_SHORT).show();
+        if(handler != null) {
+            handler.handleGetCredentialsResult(
+                    success != null && success, credentials, wallabagVersion
+            );
         }
+    }
+
+    public interface ResultHandler {
+        void handleGetCredentialsResult(
+                Boolean success, FeedsCredentials credentials, int wallabagVersion
+        );
     }
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/TestConnectionTask.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/tasks/TestConnectionTask.java
@@ -9,7 +9,6 @@ import android.util.Log;
 import java.io.IOException;
 
 import fr.gaulupeau.apps.InThePoche.R;
-import fr.gaulupeau.apps.Poche.network.WallabagConnection;
 import fr.gaulupeau.apps.Poche.network.WallabagService;
 
 public class TestConnectionTask extends AsyncTask<Void, Void, Integer> {
@@ -34,7 +33,7 @@ public class TestConnectionTask extends AsyncTask<Void, Void, Integer> {
 
     @Override
     protected Integer doInBackground(Void... params) {
-        WallabagService service = new WallabagService(endpoint, username, password);
+        WallabagService service = new WallabagService(endpoint, username, password, -1);
         try {
             int result = service.testConnection();
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/BaseActionBarActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/BaseActionBarActivity.java
@@ -1,13 +1,13 @@
 package fr.gaulupeau.apps.Poche.ui;
 
-
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.MenuItem;
 
 public class BaseActionBarActivity extends AppCompatActivity {
+
+    private static final String TAG = BaseActionBarActivity.class.getSimpleName();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -19,7 +19,7 @@ public class BaseActionBarActivity extends AppCompatActivity {
         try {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         } catch (Exception e) {
-            //
+            Log.w(TAG, e);
         }
     }
 
@@ -27,7 +27,7 @@ public class BaseActionBarActivity extends AppCompatActivity {
         try {
             getSupportActionBar().setDisplayHomeAsUpEnabled(false);
         } catch (Exception e) {
-            //
+            Log.w(TAG, e);
         }
     }
 

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -141,6 +141,20 @@
                 android:inputType="text" />
         </android.support.design.widget.TextInputLayout>
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/toppadding"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:text="@string/settings_wallabagVersion" />
+
+        <android.support.v7.widget.AppCompatSpinner
+            android:id="@+id/versionChooser"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="5sp"
+            android:entries="@array/wallabag_versions" />
+
         <CheckBox
             android:id="@+id/accept_all_certs_cb"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="wallabag_versions">
+        <item>V1</item>
+        <item>V2</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="settings_b_getFeedCredentials_text">Get feeds credentials</string>
     <string name="settings_feedsCredentials">Feeds credentials (required)</string>
     <string name="settings_feedsCredentialsDesc">Used to get articles from server</string>
+    <string name="settings_wallabagVersion">Wallabag server version:</string>
     <string name="settings_testingConnection">Testing connection</string>
     <string name="settings_gettingCredentials">Getting credentials</string>
     <string name="addLink_errorMessage">Couldn\'t add link</string>


### PR DESCRIPTION
Mostly minor refactoring. The only more or less significant change is lazy initialization of `serviceEndpoint` in `WallabagService` -- the constructor is sometimes called in UI thread, that should not wait for `guessWallabagVersion()` to finish.

BTW, we have to do something with wallabag version guessing: right now the app makes at least two additional calls to server before **every** request (mark read, favorite, etc.). We shouldn't do that on mobile phones (well, *especially* on mobile phones).
The most viable solution is to detect server version on saving settings, but it's not very convenient.
It is also possible to add "Wallabag server version" switch to the settings screen, which would be automatically set via 'Get credentials' button.