### PR TITLE
Add "Custom SSL settings" option

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -15,6 +15,7 @@ public class Settings {
     public static final String USER_ID = "APIUsername";
     public static final String TOKEN = "APIToken";
     public static final String ALL_CERTS = "all_certs";
+    public static final String CUSTOM_SSL_SETTINGS = "custom_ssl_settings";
     public static final String FONT_SIZE = "font_size";
     public static final String SERIF_FONT = "serif_font";
     public static final String LIST_LIMIT = "list_limit";
@@ -76,9 +77,12 @@ public class Settings {
         return pref.getFloat(key, defValue);
     }
 
-
     public boolean getBoolean(String key, boolean defValue) {
         return pref.getBoolean(key, defValue);
+    }
+
+    public boolean contains(String key) {
+        return pref.contains(key);
     }
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/SettingsActivity.java
@@ -4,6 +4,7 @@ import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.AppCompatSpinner;
@@ -44,6 +45,7 @@ public class SettingsActivity extends BaseActionBarActivity
     private EditText editAPIToken;
     private AppCompatSpinner versionChooser;
     private CheckBox allCerts;
+    private CheckBox customSSLSettings;
     private AppCompatSpinner themeChooser;
     private EditText fontSizeET;
     private CheckBox serifFont;
@@ -79,6 +81,7 @@ public class SettingsActivity extends BaseActionBarActivity
         editAPIToken = (EditText) findViewById(R.id.APIToken);
         versionChooser = (AppCompatSpinner) findViewById(R.id.versionChooser);
         allCerts = (CheckBox) findViewById(R.id.accept_all_certs_cb);
+        customSSLSettings = (CheckBox) findViewById(R.id.custom_ssl_settings_cb);
         themeChooser = (AppCompatSpinner) findViewById(R.id.themeChooser);
         fontSizeET = (EditText) findViewById(R.id.fontSizeET);
         serifFont = (CheckBox) findViewById(R.id.ui_font_serif);
@@ -92,6 +95,15 @@ public class SettingsActivity extends BaseActionBarActivity
         versionChooser.setSelection(settings.getInt(Settings.WALLABAG_VERSION, 2) - 1);
 
         allCerts.setChecked(settings.getBoolean(Settings.ALL_CERTS, false));
+
+        boolean customSSL = false;
+        if(settings.contains(Settings.CUSTOM_SSL_SETTINGS)) {
+            customSSL = settings.getBoolean(Settings.CUSTOM_SSL_SETTINGS, false);
+        } else if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1
+                && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            customSSL = true;
+        }
+        customSSLSettings.setChecked(customSSL);
 
         Themes.Theme[] themes = Themes.Theme.values();
         String[] themeOptions = new String[themes.length];
@@ -193,6 +205,7 @@ public class SettingsActivity extends BaseActionBarActivity
                 settings.setInt(Settings.WALLABAG_VERSION, versionChooser.getSelectedItemPosition() + 1);
 
                 settings.setBoolean(Settings.ALL_CERTS, allCerts.isChecked());
+                settings.setBoolean(Settings.CUSTOM_SSL_SETTINGS, customSSLSettings.isChecked());
                 Themes.Theme selectedTheme = Themes.Theme.values()[themeChooser.getSelectedItemPosition()];
                 settings.setString(Settings.THEME, selectedTheme.toString());
                 try {

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -170,6 +170,21 @@
             android:paddingBottom="5sp"
             android:text="@string/accept_all_certs_desc" />
 
+        <CheckBox
+            android:id="@+id/custom_ssl_settings_cb"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/toppadding"
+            android:text="@string/custom_ssl_settings_txt" />
+
+        <TextView
+            android:id="@+id/accept_all_certs_desc"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingBottom="5sp"
+            android:text="@string/custom_ssl_settings_desc" />
+
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,8 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="no_articles">No articles</string>
     <string name="accept_all_certs_txt">Accept all SSL certificates</string>
     <string name="accept_all_certs_desc">May require restart; insecure; consider importing self-signed certificates into system.</string>
+    <string name="custom_ssl_settings_txt">Custom SSL settings</string>
+    <string name="custom_ssl_settings_desc">Disables SSL on all devices, enables TLS 1.1 and TLS 1.2 on Android 4.1–4.4</string>
     <string name="list_limit_number_text">Articles list limit</string>
     <string name="loading_article_text">Loading…</string>
     <string name="d_urlAction_title">Select an action for URL</string>


### PR DESCRIPTION
Fixes #183.
The method is used in DAVdroid, so it's probably fine.
The option is not very useful if you run Android 5+ **and** your server prefers TLS (I'm not an expert in that area, maybe MitM-attacks still can force your connection to fallback to SSL - in that case the option is useful on any recent Android version).