### PR TITLE
Add option to scroll screen by tapping on screen sides

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -39,6 +39,8 @@ public class Settings {
     public static final String TTS_VOICE = "tts.voice";
     public static final String TTS_LANGUAGE_VOICE = "tts.language_voice:";
     public static final String TTS_AUTOPLAY_NEXT = "tts.autoplay_next";
+    public static final String TOUCH_SCROLL = "touch_scroll";
+    public static final String TOUCH_SCROLL_PERCENT = "touch_scroll_percent";
     public static final int WALLABAG_WIDGET_MAX_UNREAD_COUNT = 999;
 
     private SharedPreferences pref;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -79,6 +79,9 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
     private boolean acceptAllSSLCerts;
 
+    private boolean touchScroll;
+    private float touchScrollPercent;
+
     private String titleText;
     private String originalUrlText;
     private String domainText;
@@ -137,6 +140,9 @@ public class ReadArticleActivity extends BaseActionBarActivity {
         settings = App.getInstance().getSettings();
 
         acceptAllSSLCerts = settings.getBoolean(Settings.ALL_CERTS, false);
+
+        touchScroll = settings.getBoolean(Settings.TOUCH_SCROLL, false);
+        touchScrollPercent = settings.getFloat(Settings.TOUCH_SCROLL_PERCENT, 0);
 
         String cssName;
         boolean highContrast = false;
@@ -320,6 +326,37 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                     openPreviousArticle();
                 }
                 return true;
+            }
+
+            @Override
+            public boolean onSingleTapConfirmed(MotionEvent e) {
+                if(!touchScroll) return false;
+
+                if(e.getPointerCount() > 1) return false;
+
+                int viewHeight = scrollView.getHeight();
+                int yOffset = scrollView.getScrollY();
+                float y = e.getY() - yOffset;
+
+                if(y > viewHeight * 0.25 && y < viewHeight * 0.75) {
+                    int viewWidth = scrollView.getWidth();
+                    float x = e.getX();
+
+                    int newYOffset = yOffset;
+                    int step = (int)(viewHeight * touchScrollPercent / 100);
+                    if(x < viewWidth * 0.3) { // left part
+                        newYOffset -= step;
+                    } else if(x > viewWidth * 0.7) { // right part
+                        newYOffset += step;
+                    }
+
+                    if(newYOffset != yOffset) {
+                        scrollView.scrollTo(scrollView.getScrollX(), newYOffset);
+                        return true;
+                    }
+                }
+
+                return false;
             }
         };
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/SettingsActivity.java
@@ -50,6 +50,8 @@ public class SettingsActivity extends BaseActionBarActivity
     private EditText fontSizeET;
     private CheckBox serifFont;
     private EditText listLimit;
+    private CheckBox touchScroll;
+    private EditText touchScrollPercent;
     private CheckBox handleHttpScheme;
     private TextView textViewVersion;
     private EditText username;
@@ -87,6 +89,8 @@ public class SettingsActivity extends BaseActionBarActivity
         fontSizeET = (EditText) findViewById(R.id.fontSizeET);
         serifFont = (CheckBox) findViewById(R.id.ui_font_serif);
         listLimit = (EditText) findViewById(R.id.list_limit_number);
+        touchScroll = (CheckBox) findViewById(R.id.ui_touch_scroll);
+        touchScrollPercent = (EditText) findViewById(R.id.ui_touch_scroll_percent);
         handleHttpScheme = (CheckBox) findViewById(R.id.handle_http_scheme);
 
         editPocheUrl.setText(wallabagSettings.wallabagURL);
@@ -123,6 +127,9 @@ public class SettingsActivity extends BaseActionBarActivity
 
         serifFont.setChecked(settings.getBoolean(Settings.SERIF_FONT, false));
         listLimit.setText(String.valueOf(settings.getInt(Settings.LIST_LIMIT, 50)));
+
+        touchScroll.setChecked(settings.getBoolean(Settings.TOUCH_SCROLL, false));
+        touchScrollPercent.setText(String.valueOf(settings.getFloat(Settings.TOUCH_SCROLL_PERCENT, 90)));
 
         handleHttpScheme.setChecked(settings.isHandlingHttpScheme());
 
@@ -218,6 +225,12 @@ public class SettingsActivity extends BaseActionBarActivity
                 settings.setBoolean(Settings.SERIF_FONT, serifFont.isChecked());
                 try {
                     settings.setInt(Settings.LIST_LIMIT, Integer.parseInt(listLimit.getText().toString()));
+                } catch (NumberFormatException ignored) {}
+
+                settings.setBoolean(Settings.TOUCH_SCROLL, touchScroll.isChecked());
+                try {
+                    settings.setFloat(Settings.TOUCH_SCROLL_PERCENT,
+                            Float.parseFloat(touchScrollPercent.getText().toString()));
                 } catch (NumberFormatException ignored) {}
 
                 settings.setHandleHttpScheme(handleHttpScheme.isChecked());

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -291,6 +291,32 @@
         </android.support.design.widget.TextInputLayout>
 
         <CheckBox
+            android:id="@+id/ui_touch_scroll"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/toppadding"
+            android:text="@string/settings_ui_touch_scroll" />
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/toppadding" >
+
+            <EditText
+                android:id="@+id/ui_touch_scroll_percent"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:ems="10"
+                android:hint="@string/settings_ui_touch_scroll_percent"
+                android:inputType="numberDecimal|numberSigned"
+                android:linksClickable="false"
+                android:maxLines="1"
+                android:scrollHorizontally="false" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <CheckBox
             android:id="@+id/handle_http_scheme"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,8 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="themeName_solarized">Solarized</string>
     <string name="settings_ui_fontSize">Article font size (%)</string>
     <string name="settings_ui_serif">Serif typeface for article fonts</string>
+    <string name="settings_ui_touch_scroll">Scroll screen by tapping on left and right screen sides</string>
+    <string name="settings_ui_touch_scroll_percent">Percent of screen height to scroll</string>
     <string name="menu_readArticle_increaseFontSize">Increase font size</string>
     <string name="menu_readArticle_decreaseFontSize">Decrease font size</string>
     <string name="menu_readArticle_switchFontFamily">Switch font family</string>


### PR DESCRIPTION
The "sides" are limited by:
* height: (0.25; 0.75) scrollView's height;
* width: left is [0; 0.3) of scrollView's width and right is (0.7; 1].

For some reason touch events are not consumed: if you tap on a link it will both scroll and open link menu.

#168.
