### PR TITLE
Minor improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,10 +38,10 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.2.0'
-    compile 'com.android.support:support-v4:24.2.0'
-    compile 'com.android.support:recyclerview-v7:24.2.0'
-    compile 'com.android.support:design:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:support-v4:24.2.1'
+    compile 'com.android.support:recyclerview-v7:24.2.1'
+    compile 'com.android.support:design:24.2.1'
     compile 'org.greenrobot:eventbus:3.0.0'
     compile 'org.greenrobot:greendao:2.2.1'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/DbConnection.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/DbConnection.java
@@ -85,6 +85,8 @@ public class DbConnection {
             DaoMaster.dropAllTables(db, true);
             onCreate(db);
 
+            new Settings(context).setFirstSyncDone(false);
+
             if(offlineUrls != null && !offlineUrls.isEmpty()) {
                 boolean inserted = false;
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -466,6 +466,14 @@ public class Settings {
         setBoolean(R.string.pref_key_autoSyncQueue_enabled, value);
     }
 
+    public boolean isAutoDownloadNewArticlesEnabled() {
+        return getBoolean(R.string.pref_key_autoDlNew_enabled, false);
+    }
+
+    public void setAutoDownloadNewArticlesEnabled(boolean value) {
+        setBoolean(R.string.pref_key_autoDlNew_enabled, value);
+    }
+
     public boolean isFirstRun() {
         return getBoolean(R.string.pref_key_internal_firstRun, true);
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -35,20 +35,24 @@ public class Settings {
     public static void init(Context c) {
         preferenceKeysMap = new HashMap<>();
 
-        for(Field field: R.string.class.getDeclaredFields()) {
-            int modifiers = field.getModifiers();
-            if(Modifier.isStatic(modifiers)
-                    && !Modifier.isPrivate(modifiers)
-                    && field.getType().equals(int.class)) {
-                try {
-                    if(field.getName().startsWith("pref_key_")) {
-                        int resID = field.getInt(null);
-                        addToMap(c, resID);
+        try {
+            for(Field field: R.string.class.getDeclaredFields()) {
+                int modifiers = field.getModifiers();
+                if(Modifier.isStatic(modifiers)
+                        && !Modifier.isPrivate(modifiers)
+                        && field.getType().equals(int.class)) {
+                    try {
+                        if(field.getName().startsWith("pref_key_")) {
+                            int resID = field.getInt(null);
+                            addToMap(c, resID);
+                        }
+                    } catch(IllegalArgumentException | IllegalAccessException e) {
+                        Log.e(TAG, "init() exception", e);
                     }
-                } catch(IllegalArgumentException | IllegalAccessException e) {
-                    Log.e(TAG, "init() exception", e);
                 }
             }
+        } catch(Exception e) {
+            Log.e(TAG, "init() exception", e);
         }
     }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagConnection.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagConnection.java
@@ -69,6 +69,14 @@ public class WallabagConnection {
         return networkInfo != null && networkInfo.isConnectedOrConnecting();
     }
 
+    public static void clearCookies(Context context) {
+        new SharedPrefsCookiePersistor(context).clear();
+    }
+
+    public static OkHttpClient replaceClient() {
+        return Holder.client = createClient();
+    }
+
     public static OkHttpClient getClient() {
         if (Holder.client != null)
             return Holder.client;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/BGService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/BGService.java
@@ -139,6 +139,7 @@ public class BGService extends IntentService {
 
         ActionResult result = new ActionResult();
         Long queueChangedLength = null;
+        boolean urlUploaded = false;
 
         DaoSession daoSession = getDaoSession();
         daoSession.getDatabase().beginTransaction();
@@ -202,6 +203,7 @@ public class BGService extends IntentService {
                         }
 
                         itemResult = addLinkRemote(link);
+                        if(itemResult == null || itemResult.isSuccess()) urlUploaded = true;
                         break;
                     }
                 }
@@ -262,6 +264,12 @@ public class BGService extends IntentService {
 
         if(queueChangedLength != null) {
             postEvent(new OfflineQueueChangedEvent(queueChangedLength));
+        }
+
+        if(urlUploaded) {
+            postEvent(new AddLinkFinishedEvent(
+                    new ActionRequest(ActionRequest.Action.AddLink),
+                    new ActionResult()));
         }
 
         Log.d(TAG, "syncOfflineQueue() finished");

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
@@ -182,9 +182,6 @@ public class ArticlesListActivity extends AppCompatActivity
             case R.id.menuSettings:
                 startActivity(new Intent(getBaseContext(), SettingsActivity.class));
                 return true;
-            case R.id.menuTestConfiguration:
-                testConfiguration();
-                return true;
             case R.id.menuBagPage:
                 startActivity(new Intent(getBaseContext(), AddActivity.class));
                 return true;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConfigurationTestHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConfigurationTestHelper.java
@@ -47,6 +47,7 @@ public class ConfigurationTestHelper
     protected int wallabagServerVersion = -1;
 
     protected boolean tryPossibleURLs;
+    protected boolean handleResult;
 
     private ResultHandler handler;
     private GetCredentialsHandler credentialsHandler;
@@ -64,13 +65,14 @@ public class ConfigurationTestHelper
 
     public ConfigurationTestHelper(Context context, ResultHandler handler,
                                    GetCredentialsHandler credentialsHandler,
-                                   Settings settings, boolean detectVersion) {
+                                   Settings settings, boolean detectVersion,
+                                   boolean handleResult) {
         this(context, handler, credentialsHandler, settings.getUrl(),
                 settings.getUsername(), settings.getPassword(),
                 settings.getFeedsUserID(), settings.getFeedsToken(),
                 settings.getHttpAuthUsername(), settings.getHttpAuthPassword(),
                 settings.isCustomSSLSettings(), settings.isAcceptAllCertificates(),
-                detectVersion ? -1 : settings.getWallabagServerVersion(), false);
+                detectVersion ? -1 : settings.getWallabagServerVersion(), false, handleResult);
     }
 
     public ConfigurationTestHelper(Context context, ResultHandler handler,
@@ -79,7 +81,8 @@ public class ConfigurationTestHelper
                                    String feedsUserID, String feedsToken,
                                    String httpAuthUsername, String httpAuthPassword,
                                    boolean customSSLSettings, boolean acceptAllCertificates,
-                                   int wallabagServerVersion, boolean tryPossibleURLs) {
+                                   int wallabagServerVersion, boolean tryPossibleURLs,
+                                   boolean handleResult) {
         this.context = context;
         this.handler = handler;
         this.credentialsHandler = credentialsHandler;
@@ -95,6 +98,7 @@ public class ConfigurationTestHelper
         this.wallabagServerVersion = wallabagServerVersion;
 
         this.tryPossibleURLs = tryPossibleURLs;
+        this.handleResult = handleResult;
 
         progressDialog = new ProgressDialog(context);
         progressDialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
@@ -342,9 +346,7 @@ public class ConfigurationTestHelper
         if(canceled) return;
 
         if(result == TestFeedsTask.Result.OK) {
-            if(handler != null) {
-                handler.onConfigurationTestSuccess(newUrl, newWallabagServerVersion);
-            } else {
+            if(handleResult) {
                 Settings settings = App.getInstance().getSettings();
 
                 if(newUrl != null) {
@@ -356,10 +358,10 @@ public class ConfigurationTestHelper
 
                 Toast.makeText(context, R.string.settings_parametersAreOk, Toast.LENGTH_SHORT).show();
             }
+
+            handler.onConfigurationTestSuccess(newUrl, newWallabagServerVersion);
         } else {
-            if(handler != null) {
-                handler.onFeedsTestFail(result, details);
-            } else {
+            if(handleResult) {
                 String errorMessage;
                 if(result != null) {
                     switch(result) {
@@ -387,6 +389,8 @@ public class ConfigurationTestHelper
                         .setPositiveButton(R.string.ok, null)
                         .show();
             }
+
+            handler.onFeedsTestFail(result, details);
         }
     }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
@@ -341,7 +341,7 @@ public class ConnectionWizardActivity extends AppCompatActivity {
             configurationTestHelper = new ConfigurationTestHelper(
                     activity, this, this, url, username, password, feedsUserID, feedsToken,
                     httpAuthUsername, httpAuthPassword, customSSLSettings, acceptAllCertificates,
-                    wallabagServerVersion, tryPossibleURLs);
+                    wallabagServerVersion, tryPossibleURLs, false);
             configurationTestHelper.test();
         }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -282,7 +282,7 @@ public class SettingsActivity extends AppCompatActivity {
                 }
                 case R.string.pref_key_connection_autofill: {
                     configurationTestHelper = new ConfigurationTestHelper(
-                            getActivity(), this, this, settings, true);
+                            getActivity(), this, this, settings, true, false);
                     configurationTestHelper.test();
 
                     return true;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -76,6 +76,7 @@ public class SettingsActivity extends AppCompatActivity {
         private boolean newAutoSyncQueueEnabled;
 
         private boolean connectionParametersChanged;
+        private boolean httpClientReinitializationNeeded;
 
         private ConfigurationTestHelper configurationTestHelper;
 
@@ -198,8 +199,15 @@ public class SettingsActivity extends AppCompatActivity {
             if(connectionParametersChanged) {
                 connectionParametersChanged = false;
 
-                Log.i(TAG, "onStop() setting isConfigurationOk(false)");
+                Log.i(TAG, "onPause() setting isConfigurationOk(false)");
                 settings.setConfigurationOk(false);
+            }
+
+            if(httpClientReinitializationNeeded) {
+                httpClientReinitializationNeeded = false;
+
+                Log.i(TAG, "onPause() calling WallabagConnection.replaceClient()");
+                WallabagConnection.replaceClient();
             }
 
             super.onPause();
@@ -250,12 +258,14 @@ public class SettingsActivity extends AppCompatActivity {
                     newAutoSyncQueueEnabled = settings.isAutoSyncQueueEnabled();
                     break;
 
+                case R.string.pref_key_connection_advanced_acceptAllCertificates:
+                case R.string.pref_key_connection_advanced_customSSLSettings:
+                    Log.d(TAG, "onSharedPreferenceChanged() httpClientReinitializationNeeded");
+                    httpClientReinitializationNeeded = true;
                 case R.string.pref_key_connection_url:
                 case R.string.pref_key_connection_username:
                 case R.string.pref_key_connection_password:
                 case R.string.pref_key_connection_serverVersion:
-                case R.string.pref_key_connection_advanced_acceptAllCertificates:
-                case R.string.pref_key_connection_advanced_customSSLSettings:
                 case R.string.pref_key_connection_advanced_httpAuthUsername:
                 case R.string.pref_key_connection_advanced_httpAuthPassword:
                 case R.string.pref_key_connection_feedsUserID:

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -18,6 +18,7 @@ import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.App;
 import fr.gaulupeau.apps.Poche.data.DbConnection;
 import fr.gaulupeau.apps.Poche.data.Settings;
+import fr.gaulupeau.apps.Poche.network.WallabagConnection;
 import fr.gaulupeau.apps.Poche.network.WallabagServiceEndpoint;
 import fr.gaulupeau.apps.Poche.network.tasks.TestFeedsTask;
 import fr.gaulupeau.apps.Poche.service.AlarmHelper;
@@ -90,6 +91,7 @@ public class SettingsActivity extends AppCompatActivity {
 
             setOnClickListener(R.string.pref_key_connection_wizard);
             setOnClickListener(R.string.pref_key_connection_autofill);
+            setOnClickListener(R.string.pref_key_connection_advanced_clearCookies);
             setOnClickListener(R.string.pref_key_misc_wipeDB);
 
             ListPreference themeListPreference = (ListPreference)findPreference(
@@ -284,6 +286,19 @@ public class SettingsActivity extends AppCompatActivity {
                     configurationTestHelper = new ConfigurationTestHelper(
                             getActivity(), this, this, settings, true, false);
                     configurationTestHelper.test();
+
+                    return true;
+                }
+                case R.string.pref_key_connection_advanced_clearCookies: {
+                    Activity activity = getActivity();
+                    if(activity != null) {
+                        WallabagConnection.clearCookies(getActivity());
+                        WallabagConnection.replaceClient();
+
+                        Toast.makeText(activity,
+                                R.string.pref_toast_connection_advanced_clearCookies,
+                                Toast.LENGTH_SHORT).show();
+                    }
 
                     return true;
                 }

--- a/app/src/main/res/menu/option_list.xml
+++ b/app/src/main/res/menu/option_list.xml
@@ -11,10 +11,10 @@
         android:title="@string/update_allFeeds"
         android:icon="@drawable/ic_action_refresh"
         app:showAsAction="ifRoom" />
-    <item android:id="@+id/menuOpenRandomArticle"
-        android:title="@string/menu_open_random_article" />
     <item android:id="@+id/menuSyncQueue"
         android:title="@string/menu_syncLocalChanges" />
+    <item android:id="@+id/menuOpenRandomArticle"
+        android:title="@string/menu_open_random_article" />
     <item android:id="@+id/menuSettings"
         android:title="@string/btnSettings" />
     <item android:id="@+id/menuAbout"

--- a/app/src/main/res/menu/option_list.xml
+++ b/app/src/main/res/menu/option_list.xml
@@ -17,8 +17,6 @@
         android:title="@string/menu_syncLocalChanges" />
     <item android:id="@+id/menuSettings"
         android:title="@string/btnSettings" />
-    <item android:id="@+id/menuTestConfiguration"
-        android:title="Test configuration" />
     <item android:id="@+id/menuAbout"
         android:title="@string/menuAbout" />
 </menu>

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -42,4 +42,5 @@
 
     <string name="pref_key_connection_wizard" translatable="false">connection.wizard</string>
     <string name="pref_key_connection_autofill" translatable="false">connection.autofill</string>
+    <string name="pref_key_connection_advanced_clearCookies" translatable="false">connection.advanced.clearCookies</string>
 </resources>

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -29,6 +29,7 @@
     <string name="pref_key_autoSync_interval" translatable="false">autoSync.interval</string>
     <string name="pref_key_autoSync_type" translatable="false">autoSync.type</string>
     <string name="pref_key_autoSyncQueue_enabled" translatable="false">autoSyncQueue.enabled</string>
+    <string name="pref_key_autoDlNew_enabled" translatable="false">autoDlNew.enabled</string>
 
     <string name="pref_key_misc_handleHttpScheme" translatable="false">misc.handleHttpScheme</string>
     <string name="pref_key_misc_wipeDB" translatable="false">misc.wipeDB</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,8 @@ GAULUPEAU Jonathan — 2013-2015
     </string-array>
     <string name="pref_name_autoSyncQueue_enabled">Separate auto-sync for local changes</string>
     <string name="pref_desc_autoSyncQueue_enabled">This allows local changes (added links, archived articles, etc.) to be synced to the server as soon as network becomes available</string>
+    <string name="pref_name_autoDlNew_enabled">Download new articles on addition</string>
+    <string name="pref_desc_autoDlNew_enabled">Automatically download new articles right after they were added via the app. Note: download will not happen if you have unsynchronized offline changes.</string>
 
     <string name="pref_categoryName_miscellaneous">Miscellaneous</string>
     <string name="pref_name_misc_handleHttpScheme">Handle HTTP scheme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,10 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="pref_name_connection_advanced_httpAuthUsername">HTTP Auth username</string>
     <string name="pref_name_connection_advanced_httpAuthPassword">HTTP Auth password</string>
 
+    <string name="pref_name_connection_advanced_clearCookies">Clear cookies</string>
+    <string name="pref_desc_connection_advanced_clearCookies">Resets the established login session (if any)</string>
+    <string name="pref_toast_connection_advanced_clearCookies">Cookies cleared</string>
+
     <string name="pref_categoryName_ui">UI</string>
     <string name="pref_name_ui_theme">Application theme</string>
     <string name="pref_name_ui_article_fontSize">Article font size (%)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,9 +203,9 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="pref_name_misc_wipeDB_confirmTitle">Wipe Database?</string>
     <string name="pref_name_misc_wipeDB_confirmMessage">Are you sure you want to wipe database?</string>
 
-    <string name="connectionWizard_welcome_titleMessage">Welcome to Wallabag</string>
-    <string name="connectionWizard_welcome_text">Something welcoming here. Blah-blah-blah.</string>
-    <string name="connectionWizard_welcome_rerunNotice">You can always re-run this wizard from the Settings screen.</string>
+    <string name="connectionWizard_welcome_titleMessage">Welcome to Wallabag!</string>
+    <string name="connectionWizard_welcome_text">Before you can use Wallabag app you need to set up connection. This connection wizard will try to help you with it.</string>
+    <string name="connectionWizard_welcome_rerunNotice">You can always re-run the connection wizard from the Settings screen.</string>
     <string name="connectionWizard_welcome_prev">Skip</string>
     <string name="connectionWizard_welcome_next">Next</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -64,6 +64,10 @@
                     android:inputType="textPassword"
                     android:defaultValue="" />
             </PreferenceCategory>
+            <Preference
+                android:key="@string/pref_key_connection_advanced_clearCookies"
+                android:title="@string/pref_name_connection_advanced_clearCookies"
+                android:summary="@string/pref_desc_connection_advanced_clearCookies"/>
         </PreferenceScreen>
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_categoryName_ui">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -117,6 +117,11 @@
             android:title="@string/pref_name_autoSyncQueue_enabled"
             android:summary="@string/pref_desc_autoSyncQueue_enabled"
             android:defaultValue="false" />
+        <CheckBoxPreference
+            android:key="@string/pref_key_autoDlNew_enabled"
+            android:title="@string/pref_name_autoDlNew_enabled"
+            android:summary="@string/pref_desc_autoDlNew_enabled"
+            android:defaultValue="false" />
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_categoryName_miscellaneous">
         <CheckBoxPreference


### PR DESCRIPTION
Follow-up changes for #282. Mostly minor changes.

* Improved migration flow: app launch; suggestion to test connection; if connection is fine, automatically start to update feeds.
* Hide "Sync local changes" from menu if no unsynced changes.
* Add an option to clear cookies.
* Apply some connection parameters changes without restart (as for now: "Accept all SSL certs" and "Custom SSL settings").
* Update support libs. Other minor changes.