### PR TITLE
Add tap-to-scroll option

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -370,6 +370,22 @@ public class Settings {
         setString(R.string.pref_key_ui_theme, theme.toString());
     }
 
+    public boolean isTapToScrollEnabled() {
+        return getBoolean(R.string.pref_key_ui_tapToScroll_enabled, false);
+    }
+
+    public void setTapToScrollEnabled(boolean value) {
+        setBoolean(R.string.pref_key_ui_tapToScroll_enabled, value);
+    }
+
+    public float getTapToScrollPercent() {
+        return getFloat(R.string.pref_key_ui_tapToScroll_percent, 95);
+    }
+
+    public void setTapToScrollPercent(float percent) {
+        setFloat(R.string.pref_key_ui_tapToScroll_percent, percent);
+    }
+
     public boolean isTtsVisible() {
         return getBoolean(R.string.pref_key_tts_visible, false);
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -370,6 +370,14 @@ public class Settings {
         setString(R.string.pref_key_ui_theme, theme.toString());
     }
 
+    public boolean isVolumeButtonsScrollingEnabled() {
+        return getBoolean(R.string.pref_key_ui_volumeButtonsScrolling_enabled, false);
+    }
+
+    public void setVolumeButtonsScrollingEnabled(boolean value) {
+        setBoolean(R.string.pref_key_ui_volumeButtonsScrolling_enabled, value);
+    }
+
     public boolean isTapToScrollEnabled() {
         return getBoolean(R.string.pref_key_ui_tapToScroll_enabled, false);
     }
@@ -378,12 +386,20 @@ public class Settings {
         setBoolean(R.string.pref_key_ui_tapToScroll_enabled, value);
     }
 
-    public float getTapToScrollPercent() {
-        return getFloat(R.string.pref_key_ui_tapToScroll_percent, 95);
+    public float getScreenScrollingPercent() {
+        return getFloat(R.string.pref_key_ui_screenScrolling_percent, 95);
     }
 
-    public void setTapToScrollPercent(float percent) {
-        setFloat(R.string.pref_key_ui_tapToScroll_percent, percent);
+    public void setScreenScrollingPercent(float percent) {
+        setFloat(R.string.pref_key_ui_screenScrolling_percent, percent);
+    }
+
+    public boolean isScreenScrollingSmooth() {
+        return getBoolean(R.string.pref_key_ui_screenScrolling_smooth, true);
+    }
+
+    public void setScreenScrollingSmooth(boolean value) {
+        setBoolean(R.string.pref_key_ui_screenScrolling_smooth, value);
     }
 
     public boolean isTtsVisible() {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -12,6 +12,7 @@ import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
 import android.util.Log;
 import android.view.GestureDetector;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -82,8 +83,10 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
     private boolean acceptAllSSLCerts;
 
+    private boolean volumeButtonsScrolling;
     private boolean tapToScroll;
-    private float tapToScrollPercent;
+    private float screenScrollingPercent;
+    private boolean smoothScrolling;
 
     private String titleText;
     private String originalUrlText;
@@ -144,8 +147,10 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
         acceptAllSSLCerts = settings.isAcceptAllCertificates();
 
+        volumeButtonsScrolling = settings.isVolumeButtonsScrollingEnabled();
         tapToScroll = settings.isTapToScrollEnabled();
-        tapToScrollPercent = settings.getTapToScrollPercent();
+        screenScrollingPercent = settings.getScreenScrollingPercent();
+        smoothScrolling = settings.isScreenScrollingSmooth();
 
         String cssName;
         boolean highContrast = false;
@@ -336,24 +341,16 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                 if(e.getPointerCount() > 1) return false;
 
                 int viewHeight = scrollView.getHeight();
-                int yOffset = scrollView.getScrollY();
-                float y = e.getY() - yOffset;
+                float y = e.getY() - scrollView.getScrollY();
 
                 if(y > viewHeight * 0.25 && y < viewHeight * 0.75) {
                     int viewWidth = scrollView.getWidth();
                     float x = e.getX();
 
-                    int newYOffset = yOffset;
-                    int step = (int)(viewHeight * tapToScrollPercent / 100);
                     if(x < viewWidth * 0.3) { // left part
-                        newYOffset -= step;
+                        scroll(true, screenScrollingPercent, smoothScrolling);
                     } else if(x > viewWidth * 0.7) { // right part
-                        newYOffset += step;
-                    }
-
-                    if(newYOffset != yOffset) {
-                        scrollView.scrollTo(scrollView.getScrollX(), newYOffset);
-                        return true;
+                        scroll(false, screenScrollingPercent, smoothScrolling);
                     }
                 }
 
@@ -659,6 +656,22 @@ public class ReadArticleActivity extends BaseActionBarActivity {
         }
     }
 
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        if(volumeButtonsScrolling) {
+            switch(event.getKeyCode()) {
+                case KeyEvent.KEYCODE_VOLUME_UP:
+                    scroll(true, screenScrollingPercent, smoothScrolling);
+                    return true;
+                case KeyEvent.KEYCODE_VOLUME_DOWN:
+                    scroll(false, screenScrollingPercent, smoothScrolling);
+                    return true;
+            }
+        }
+
+        return super.dispatchKeyEvent(event);
+    }
+
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onArticlesChangedEvent(ArticlesChangedEvent event) {
         Log.d(TAG, "onArticlesChangedEvent() started");
@@ -677,6 +690,29 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                 Log.d(TAG, "onArticleChangedEvent() calling invalidateOptionsMenu()");
                 invalidateOptionsMenu();
                 break;
+        }
+    }
+
+    private void scroll(boolean up, float percent, boolean smooth) {
+        if(scrollView == null) return;
+
+        int viewHeight = scrollView.getHeight();
+        int yOffset = scrollView.getScrollY();
+
+        int newYOffset = yOffset;
+        int step = (int)(viewHeight * percent / 100);
+        if(up) {
+            newYOffset -= step;
+        } else {
+            newYOffset += step;
+        }
+
+        if(newYOffset != yOffset) {
+            if(smooth) {
+                scrollView.smoothScrollTo(scrollView.getScrollX(), newYOffset);
+            } else {
+                scrollView.scrollTo(scrollView.getScrollX(), newYOffset);
+            }
         }
     }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -82,6 +82,9 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
     private boolean acceptAllSSLCerts;
 
+    private boolean tapToScroll;
+    private float tapToScrollPercent;
+
     private String titleText;
     private String originalUrlText;
     private String domainText;
@@ -140,6 +143,9 @@ public class ReadArticleActivity extends BaseActionBarActivity {
         settings = App.getInstance().getSettings();
 
         acceptAllSSLCerts = settings.isAcceptAllCertificates();
+
+        tapToScroll = settings.isTapToScrollEnabled();
+        tapToScrollPercent = settings.getTapToScrollPercent();
 
         String cssName;
         boolean highContrast = false;
@@ -321,6 +327,37 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                     openPreviousArticle();
                 }
                 return true;
+            }
+
+            @Override
+            public boolean onSingleTapConfirmed(MotionEvent e) {
+                if(!tapToScroll) return false;
+
+                if(e.getPointerCount() > 1) return false;
+
+                int viewHeight = scrollView.getHeight();
+                int yOffset = scrollView.getScrollY();
+                float y = e.getY() - yOffset;
+
+                if(y > viewHeight * 0.25 && y < viewHeight * 0.75) {
+                    int viewWidth = scrollView.getWidth();
+                    float x = e.getX();
+
+                    int newYOffset = yOffset;
+                    int step = (int)(viewHeight * tapToScrollPercent / 100);
+                    if(x < viewWidth * 0.3) { // left part
+                        newYOffset -= step;
+                    } else if(x > viewWidth * 0.7) { // right part
+                        newYOffset += step;
+                    }
+
+                    if(newYOffset != yOffset) {
+                        scrollView.scrollTo(scrollView.getScrollX(), newYOffset);
+                        return true;
+                    }
+                }
+
+                return false;
             }
         };
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/FloatEditTextPreference.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/FloatEditTextPreference.java
@@ -1,0 +1,46 @@
+package fr.gaulupeau.apps.Poche.ui.preferences;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.preference.EditTextPreference;
+import android.util.AttributeSet;
+
+/**
+ * Based on http://kvance.livejournal.com/1039349.html
+ */
+public class FloatEditTextPreference extends EditTextPreference {
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public FloatEditTextPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public FloatEditTextPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public FloatEditTextPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public FloatEditTextPreference(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected boolean persistString(String value) {
+        return value != null && persistFloat(Float.valueOf(value));
+    }
+
+    @Override
+    protected String getPersistedString(String defaultReturnValue) {
+        if(!shouldPersist() || !getSharedPreferences().contains(getKey())) {
+            return defaultReturnValue;
+        }
+
+        return String.valueOf(getSharedPreferences().getFloat(getKey(), 0));
+    }
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -57,7 +57,7 @@ public class SettingsActivity extends AppCompatActivity {
                 R.string.pref_key_ui_theme,
                 R.string.pref_key_ui_article_fontSize,
                 R.string.pref_key_ui_lists_limit,
-                R.string.pref_key_ui_tapToScroll_percent,
+                R.string.pref_key_ui_screenScrolling_percent,
                 R.string.pref_key_autoSync_interval,
                 R.string.pref_key_autoSync_type
         };
@@ -414,7 +414,7 @@ public class SettingsActivity extends AppCompatActivity {
                 case R.string.pref_key_connection_advanced_httpAuthUsername:
                 case R.string.pref_key_ui_article_fontSize:
                 case R.string.pref_key_ui_lists_limit:
-                case R.string.pref_key_ui_tapToScroll_percent:
+                case R.string.pref_key_ui_screenScrolling_percent:
                     setEditTextSummaryFromContent(key);
                     break;
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -57,6 +57,7 @@ public class SettingsActivity extends AppCompatActivity {
                 R.string.pref_key_ui_theme,
                 R.string.pref_key_ui_article_fontSize,
                 R.string.pref_key_ui_lists_limit,
+                R.string.pref_key_ui_tapToScroll_percent,
                 R.string.pref_key_autoSync_interval,
                 R.string.pref_key_autoSync_type
         };
@@ -413,6 +414,7 @@ public class SettingsActivity extends AppCompatActivity {
                 case R.string.pref_key_connection_advanced_httpAuthUsername:
                 case R.string.pref_key_ui_article_fontSize:
                 case R.string.pref_key_ui_lists_limit:
+                case R.string.pref_key_ui_tapToScroll_percent:
                     setEditTextSummaryFromContent(key);
                     break;
 

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -15,6 +15,8 @@
     <string name="pref_key_ui_article_fontSerif" translatable="false">ui.article.fontSerif</string>
     <string name="pref_key_ui_lists_limit" translatable="false">ui.lists.limit</string>
     <string name="pref_key_ui_theme" translatable="false">ui.theme</string>
+    <string name="pref_key_ui_tapToScroll_enabled" translatable="false">ui.tapToScroll.enabled</string>
+    <string name="pref_key_ui_tapToScroll_percent" translatable="false">ui.tapToScroll.percent</string>
 
     <string name="pref_key_tts_visible" translatable="false">tts.visible</string>
     <string name="pref_key_tts_optionsVisible" translatable="false">tts.optionsVisible</string>

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -15,8 +15,10 @@
     <string name="pref_key_ui_article_fontSerif" translatable="false">ui.article.fontSerif</string>
     <string name="pref_key_ui_lists_limit" translatable="false">ui.lists.limit</string>
     <string name="pref_key_ui_theme" translatable="false">ui.theme</string>
+    <string name="pref_key_ui_volumeButtonsScrolling_enabled" translatable="false">ui.volumeButtonsScrolling.enabled</string>
     <string name="pref_key_ui_tapToScroll_enabled" translatable="false">ui.tapToScroll.enabled</string>
-    <string name="pref_key_ui_tapToScroll_percent" translatable="false">ui.tapToScroll.percent</string>
+    <string name="pref_key_ui_screenScrolling_percent" translatable="false">ui.screenScrolling.percent</string>
+    <string name="pref_key_ui_screenScrolling_smooth" translatable="false">ui.screenScrolling.smooth</string>
 
     <string name="pref_key_tts_visible" translatable="false">tts.visible</string>
     <string name="pref_key_tts_optionsVisible" translatable="false">tts.optionsVisible</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,10 +177,12 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="pref_name_ui_article_fontSerif">Serif typeface</string>
     <string name="pref_desc_ui_article_fontSerif">Serif typeface for article fonts</string>
     <string name="pref_name_ui_lists_limit">Articles list limit</string>
-    <string name="pref_categoryName_ui_tapToScroll">Tap-to-scroll</string>
+    <string name="pref_categoryName_ui_screenScrolling">Screen scrolling</string>
+    <string name="pref_name_ui_volumeButtonsScrolling_enabled">Scroll with volume buttons</string>
     <string name="pref_name_ui_tapToScroll_enabled">Tap-to-scroll</string>
     <string name="pref_desc_ui_tapToScroll_enabled">Scroll screen by tapping on left and right screen sides</string>
-    <string name="pref_name_ui_tapToScroll_percent">Percent of screen height to scroll</string>
+    <string name="pref_name_ui_screenScrolling_percent">Percent of screen height to scroll</string>
+    <string name="pref_name_ui_screenScrolling_smooth">Use smooth scrolling</string>
 
     <string name="pref_categoryName_autoSync">Auto-sync</string>
     <string name="pref_name_autoSync_enabled">Enable auto-sync</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,7 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="pref_name_ui_article_fontSerif">Serif typeface</string>
     <string name="pref_desc_ui_article_fontSerif">Serif typeface for article fonts</string>
     <string name="pref_name_ui_lists_limit">Articles list limit</string>
+    <string name="pref_categoryName_ui_tapToScroll">Tap-to-scroll</string>
     <string name="pref_name_ui_tapToScroll_enabled">Tap-to-scroll</string>
     <string name="pref_desc_ui_tapToScroll_enabled">Scroll screen by tapping on left and right screen sides</string>
     <string name="pref_name_ui_tapToScroll_percent">Percent of screen height to scroll</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,9 @@ GAULUPEAU Jonathan — 2013-2015
     <string name="pref_name_ui_article_fontSerif">Serif typeface</string>
     <string name="pref_desc_ui_article_fontSerif">Serif typeface for article fonts</string>
     <string name="pref_name_ui_lists_limit">Articles list limit</string>
+    <string name="pref_name_ui_tapToScroll_enabled">Tap-to-scroll</string>
+    <string name="pref_desc_ui_tapToScroll_enabled">Scroll screen by tapping on left and right screen sides</string>
+    <string name="pref_name_ui_tapToScroll_percent">Percent of screen height to scroll</string>
 
     <string name="pref_categoryName_autoSync">Auto-sync</string>
     <string name="pref_name_autoSync_enabled">Enable auto-sync</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -94,7 +94,18 @@
             android:title="@string/pref_name_ui_lists_limit"
             android:inputType="numberDecimal"
             android:defaultValue="50" />
-        </PreferenceCategory>
+        <CheckBoxPreference
+            android:key="@string/pref_key_ui_tapToScroll_enabled"
+            android:title="@string/pref_name_ui_tapToScroll_enabled"
+            android:summary="@string/pref_desc_ui_tapToScroll_enabled"
+            android:defaultValue="false" />
+        <fr.gaulupeau.apps.Poche.ui.preferences.FloatEditTextPreference
+            android:dependency="@string/pref_key_ui_tapToScroll_enabled"
+            android:key="@string/pref_key_ui_tapToScroll_percent"
+            android:title="@string/pref_name_ui_tapToScroll_percent"
+            android:inputType="numberDecimal"
+            android:defaultValue="95" />
+      </PreferenceCategory>
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_categoryName_autoSync">
       <PreferenceCategory android:title="@string/pref_categoryName_autoSync">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -95,18 +95,25 @@
             android:inputType="number"
             android:defaultValue="50" />
       </PreferenceCategory>
-        <PreferenceCategory android:title="@string/pref_categoryName_ui_tapToScroll">
+        <PreferenceCategory android:title="@string/pref_categoryName_ui_screenScrolling">
+            <CheckBoxPreference
+                android:key="@string/pref_key_ui_volumeButtonsScrolling_enabled"
+                android:title="@string/pref_name_ui_volumeButtonsScrolling_enabled"
+                android:defaultValue="false" />
             <CheckBoxPreference
                 android:key="@string/pref_key_ui_tapToScroll_enabled"
                 android:title="@string/pref_name_ui_tapToScroll_enabled"
                 android:summary="@string/pref_desc_ui_tapToScroll_enabled"
                 android:defaultValue="false" />
             <fr.gaulupeau.apps.Poche.ui.preferences.FloatEditTextPreference
-                android:dependency="@string/pref_key_ui_tapToScroll_enabled"
-                android:key="@string/pref_key_ui_tapToScroll_percent"
-                android:title="@string/pref_name_ui_tapToScroll_percent"
+                android:key="@string/pref_key_ui_screenScrolling_percent"
+                android:title="@string/pref_name_ui_screenScrolling_percent"
                 android:inputType="numberDecimal"
                 android:defaultValue="95" />
+            <CheckBoxPreference
+                android:key="@string/pref_key_ui_screenScrolling_smooth"
+                android:title="@string/pref_name_ui_screenScrolling_smooth"
+                android:defaultValue="true" />
         </PreferenceCategory>
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_categoryName_autoSync">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -82,7 +82,7 @@
         <fr.gaulupeau.apps.Poche.ui.preferences.IntEditTextPreference
             android:key="@string/pref_key_ui_article_fontSize"
             android:title="@string/pref_name_ui_article_fontSize"
-            android:inputType="numberDecimal"
+            android:inputType="number"
             android:defaultValue="100" />
         <CheckBoxPreference
             android:key="@string/pref_key_ui_article_fontSerif"
@@ -92,7 +92,7 @@
         <fr.gaulupeau.apps.Poche.ui.preferences.IntEditTextPreference
             android:key="@string/pref_key_ui_lists_limit"
             android:title="@string/pref_name_ui_lists_limit"
-            android:inputType="numberDecimal"
+            android:inputType="number"
             android:defaultValue="50" />
         <CheckBoxPreference
             android:key="@string/pref_key_ui_tapToScroll_enabled"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -94,18 +94,20 @@
             android:title="@string/pref_name_ui_lists_limit"
             android:inputType="number"
             android:defaultValue="50" />
-        <CheckBoxPreference
-            android:key="@string/pref_key_ui_tapToScroll_enabled"
-            android:title="@string/pref_name_ui_tapToScroll_enabled"
-            android:summary="@string/pref_desc_ui_tapToScroll_enabled"
-            android:defaultValue="false" />
-        <fr.gaulupeau.apps.Poche.ui.preferences.FloatEditTextPreference
-            android:dependency="@string/pref_key_ui_tapToScroll_enabled"
-            android:key="@string/pref_key_ui_tapToScroll_percent"
-            android:title="@string/pref_name_ui_tapToScroll_percent"
-            android:inputType="numberDecimal"
-            android:defaultValue="95" />
       </PreferenceCategory>
+        <PreferenceCategory android:title="@string/pref_categoryName_ui_tapToScroll">
+            <CheckBoxPreference
+                android:key="@string/pref_key_ui_tapToScroll_enabled"
+                android:title="@string/pref_name_ui_tapToScroll_enabled"
+                android:summary="@string/pref_desc_ui_tapToScroll_enabled"
+                android:defaultValue="false" />
+            <fr.gaulupeau.apps.Poche.ui.preferences.FloatEditTextPreference
+                android:dependency="@string/pref_key_ui_tapToScroll_enabled"
+                android:key="@string/pref_key_ui_tapToScroll_percent"
+                android:title="@string/pref_name_ui_tapToScroll_percent"
+                android:inputType="numberDecimal"
+                android:defaultValue="95" />
+        </PreferenceCategory>
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_categoryName_autoSync">
       <PreferenceCategory android:title="@string/pref_categoryName_autoSync">


### PR DESCRIPTION
#168.

Replaces #266.

Same note applies:

The "sides" are limited by:
 * height: (0.25; 0.75) scrollView's height;
 * width: left is [0; 0.3) of scrollView's width and right is (0.7; 1].

For some reason touch events are not consumed: if you tap on a link it will both scroll and open link menu.