### PR TITLE
Use JobScheduler on Android 5+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="fr.gaulupeau.apps.InThePoche"
-    android:installLocation="auto">
+          xmlns:tools="http://schemas.android.com/tools"
+          package="fr.gaulupeau.apps.InThePoche"
+          android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -111,7 +112,8 @@
             android:name="fr.gaulupeau.apps.Poche.network.ConnectivityChangeReceiver"
             android:enabled="false">
             <intent-filter>
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
+                <action android:name="android.net.conn.CONNECTIVITY_CHANGE"
+                        tools:ignore="BatteryLife" />
             </intent-filter>
         </receiver>
         <receiver
@@ -124,6 +126,11 @@
         <receiver
             android:name="fr.gaulupeau.apps.Poche.service.AlarmReceiver"
             android:enabled="false" />
+
+        <service
+            android:name="fr.gaulupeau.apps.Poche.service.WallabagJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="true" />
 
         <service
             android:name="fr.gaulupeau.apps.Poche.service.BGService"

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.App;
 import fr.gaulupeau.apps.Poche.network.ConnectivityChangeReceiver;
+import fr.gaulupeau.apps.Poche.service.WallabagJobService;
 import fr.gaulupeau.apps.Poche.ui.HttpSchemeHandlerActivity;
 import fr.gaulupeau.apps.Poche.ui.Themes;
 import fr.gaulupeau.apps.Poche.ui.preferences.ConnectionWizardActivity;
@@ -83,7 +84,11 @@ public class Settings {
     }
 
     public static void enableConnectivityChangeReceiver(Context context, boolean enable) {
-        enableComponent(context, ConnectivityChangeReceiver.class, enable);
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            enableComponent(context, ConnectivityChangeReceiver.class, enable);
+        } else {
+            WallabagJobService.enable(context, enable);
+        }
     }
 
     // TODO: reuse in setHandleHttpScheme

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/WallabagJobService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/WallabagJobService.java
@@ -1,0 +1,84 @@
+package fr.gaulupeau.apps.Poche.service;
+
+import android.app.job.JobInfo;
+import android.app.job.JobParameters;
+import android.app.job.JobScheduler;
+import android.app.job.JobService;
+import android.content.ComponentName;
+import android.content.Context;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+import android.util.Log;
+
+import org.greenrobot.eventbus.EventBus;
+
+import fr.gaulupeau.apps.Poche.events.ConnectivityChangedEvent;
+
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+public class WallabagJobService extends JobService {
+
+    private static final int CONNECTIVITY_CHANGE_JOB_ID = 1;
+
+    private static final String TAG = WallabagJobService.class.getSimpleName();
+
+    public static void enable(Context context, boolean enable) {
+        Log.d(TAG, String.format("enable(%s) started", enable));
+
+        JobScheduler scheduler =
+                (JobScheduler)context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+
+        if(enable) {
+            boolean alreadyScheduled = false;
+            if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                JobInfo job = scheduler.getPendingJob(CONNECTIVITY_CHANGE_JOB_ID);
+                if(job != null) alreadyScheduled = true;
+            } else {
+                for(JobInfo jobInfo: scheduler.getAllPendingJobs()) {
+                    if(jobInfo.getId() == CONNECTIVITY_CHANGE_JOB_ID) {
+                        alreadyScheduled = true;
+                        break;
+                    }
+                }
+            }
+
+            if(alreadyScheduled) {
+                Log.d(TAG, "enable() the job is already scheduled");
+                return;
+            }
+
+            ComponentName serviceName = new ComponentName(context, WallabagJobService.class);
+            JobInfo jobInfo = new JobInfo.Builder(CONNECTIVITY_CHANGE_JOB_ID, serviceName)
+                    .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                    .setPersisted(true)
+                    .build();
+
+            Log.d(TAG, "enable() trying to schedule a job");
+            int result = scheduler.schedule(jobInfo);
+            if(result == JobScheduler.RESULT_FAILURE) {
+                Log.e(TAG, "enable(): Couldn't schedule JobScheduler job");
+            } else {
+                Log.d(TAG, "enable(): JobScheduler job scheduled");
+            }
+        } else {
+            Log.d(TAG, "enable() trying to cancel a job");
+            scheduler.cancel(CONNECTIVITY_CHANGE_JOB_ID);
+        }
+    }
+
+    @Override
+    public boolean onStartJob(JobParameters params) {
+        Log.d(TAG, "onStartJob() started");
+
+        EventBus.getDefault().post(new ConnectivityChangedEvent());
+
+        // not sure about it
+        jobFinished(params, false);
+        return false;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters params) {
+        return false;
+    }
+
+}


### PR DESCRIPTION
*I initially committed it to `fix-lint-issues` branch, but I think this change should be merged ASAP.*

I fixed a `BatteryLife` warning: on Lollipop+ it will use [`JobScheduler`](https://developer.android.com/topic/performance/background-optimization.html) to schedule a job (to run it when network becomes available), on older Android versions it will use the usual BroadcastReceiver. I **did not** test it on Android 5+. It affects only "Separate auto-sync for local changes" option.
Essentially, without `JobScheduler` the `CONNECTIVITY_CHANGE` event probably won't be delivered on Android 5+.