### PR TITLE
Trim Feeds UserID instead of blindly replacing it in getCredentials()

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagService.java
@@ -105,14 +105,14 @@ public class WallabagService {
             switch(getWallabagVersion()) {
                 case 1:
                     serviceEndpoint = new WallabagServiceEndpointV1(endpoint, username, password,
-                            requestCreator, client);
+                            httpAuthUsername, httpAuthPassword, requestCreator, client);
                     break;
 
                 default:
                     Log.w(TAG, "Falling back to V2 endpoint; wallabagVersion=" + this.wallabagVersion);
                 case 2:
                     serviceEndpoint = new WallabagServiceEndpointV2(endpoint, username, password,
-                            requestCreator, client);
+                            httpAuthUsername, httpAuthPassword, requestCreator, client);
                     break;
             }
         }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpoint.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpoint.java
@@ -31,15 +31,20 @@ public abstract class WallabagServiceEndpoint {
     protected String endpoint;
     protected final String username;
     protected final String password;
+    protected final String httpAuthUsername;
+    protected final String httpAuthPassword;
     protected RequestCreator requestCreator;
 
     protected OkHttpClient client;
 
     public WallabagServiceEndpoint(String endpoint, String username, String password,
+                                   String httpAuthUsername, String httpAuthPassword,
                                    RequestCreator requestCreator, OkHttpClient client) {
         this.endpoint = endpoint;
         this.username = username;
         this.password = password;
+        this.httpAuthUsername = httpAuthUsername;
+        this.httpAuthPassword = httpAuthPassword;
         this.requestCreator = requestCreator;
         this.client = client;
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV1.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV1.java
@@ -32,9 +32,10 @@ public class WallabagServiceEndpointV1 extends WallabagServiceEndpoint {
     private static final String TAG = WallabagServiceEndpointV1.class.getSimpleName();
 
     public WallabagServiceEndpointV1(String endpoint, String username, String password,
+                                     String httpAuthUsername, String httpAuthPassword,
                                      RequestCreator requestCreator,
                                      OkHttpClient client) {
-        super(endpoint, username, password, requestCreator, client);
+        super(endpoint, username, password, httpAuthUsername, httpAuthPassword, requestCreator, client);
     }
 
     public ConnectionTestResult testConnection()

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
@@ -100,9 +100,21 @@ public class WallabagServiceEndpointV2 extends WallabagServiceEndpoint {
 
     public FeedsCredentials getCredentials() throws RequestException, IOException {
         FeedsCredentials fc = getCredentials("/config", CREDENTIALS_PATTERN);
-        // overwrite userID with username because first matcher group of previous regex, which
-        // should return the user name, might include the subdirectory in which wallabag is installed
-        if(fc != null) fc.userID = username;
+        // fc.userID might include the subdirectory in which wallabag is installed.
+        // If feed url is "https://example.com/wallabag/complex/user/name/token/unread.xml",
+        // fc.userID will be "wallabag/complex/user/name", but should be "complex/user/name"
+        if(fc != null) {
+            // TODO: do something if username is empty (only HTTP Auth used)
+            if(username != null && !username.isEmpty() && fc.userID != null
+                    && username.length() != fc.userID.length()) {
+                if(fc.userID.length() > username.length()) {
+                    Log.d(TAG, "getCredentials() fc.userID is longer than username");
+                    fc.userID = fc.userID.substring(fc.userID.length() - username.length());
+                } else {
+                    Log.w(TAG, "getCredentials() fc.userID is shorter than username");
+                }
+            }
+        }
         return fc;
     }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagServiceEndpointV2.java
@@ -100,37 +100,35 @@ public class WallabagServiceEndpointV2 extends WallabagServiceEndpoint {
 
     public FeedsCredentials getCredentials() throws RequestException, IOException {
         FeedsCredentials fc = getCredentials("/config", CREDENTIALS_PATTERN);
+        if(fc == null || fc.userID == null) return fc;
+
         // fc.userID might include the subdirectory in which wallabag is installed.
         // If feed url is "https://example.com/wallabag/complex/user/name/token/unread.xml",
         // fc.userID will be "wallabag/complex/user/name", but should be "complex/user/name".
         // The following code is an attempt to work around this issue.
-        if(fc != null) {
-            int presumedUsernameLength = (username != null && !username.isEmpty()) ? username.length()
-                    : httpAuthUsername != null ? httpAuthUsername.length() : 0;
+        int presumedUsernameLength = (username != null && !username.isEmpty()) ? username.length()
+                : httpAuthUsername != null ? httpAuthUsername.length() : 0;
 
-            boolean failedToCheck = false;
+        boolean failedToCheck = false;
 
-            if(presumedUsernameLength > 0) {
-                // if fc.userID is null, we have more serious issues and should not try to fix it here
-                if(fc.userID != null && presumedUsernameLength != fc.userID.length()) {
-                    if(fc.userID.length() > presumedUsernameLength) {
-                        Log.d(TAG, "getCredentials() fc.userID is longer than presumedUsername");
-                        fc.userID = fc.userID.substring(fc.userID.length() - presumedUsernameLength);
-                    } else {
-                        Log.i(TAG, "getCredentials() fc.userID is shorter than presumedUsername");
-                        failedToCheck = true;
-                    }
-                }
+        if(presumedUsernameLength <= 0) {
+            Log.i(TAG, "getCredentials() no presumedUsername, can't check fc.userID");
+            failedToCheck = true;
+        } else if(presumedUsernameLength != fc.userID.length()) {
+            if(fc.userID.length() > presumedUsernameLength) {
+                Log.d(TAG, "getCredentials() fc.userID is longer than presumedUsername");
+                fc.userID = fc.userID.substring(fc.userID.length() - presumedUsernameLength);
             } else {
-                Log.i(TAG, "getCredentials() no presumedUsername, can't check fc.userID");
+                Log.i(TAG, "getCredentials() fc.userID is shorter than presumedUsername");
                 failedToCheck = true;
             }
-
-            if(failedToCheck) {
-                Log.w(TAG, "getCredentials() if you see this and can't access feeds, " +
-                        "check \"feeds user ID\"");
-            }
         }
+
+        if(failedToCheck) {
+            Log.w(TAG, "getCredentials() if you see this and can't access feeds, " +
+                    "check \"feeds user ID\"");
+        }
+
         return fc;
     }
 


### PR DESCRIPTION
Use somewhat more elaborate hack to get Feeds UserID.
It still won't work if username is empty (only HTTP Auth used).
#321.