### PR TITLE
Apply proxy theme to HttpSchemeHandlerActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,7 +41,8 @@
             android:autoRemoveFromRecents="true"
             android:enabled="false"
             android:excludeFromRecents="true"
-            android:noHistory="true">
+            android:noHistory="true"
+            android:theme="@style/ProxyTheme">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 


### PR DESCRIPTION
Removes empty white activity that appears for a fraction of a second when sharing to HttpSchemeHandlerActivity.

I overlooked it when initially implemented the feature.