### PR TITLE
Replaced v2.wallabag with wallabag.it

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
@@ -489,7 +489,7 @@ public class ConnectionWizardActivity extends AppCompatActivity {
             username = usernameEditText.getText().toString();
             password = passwordEditText.getText().toString();
 
-            url = "https://www.wallabag.it";
+            url = "https://app.wallabag.it";
             wallabagServerVersion = 2;
 
             tryPossibleURLs = false;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
@@ -489,7 +489,7 @@ public class ConnectionWizardActivity extends AppCompatActivity {
             username = usernameEditText.getText().toString();
             password = passwordEditText.getText().toString();
 
-            url = "https://v2.wallabag.org";
+            url = "https://www.wallabag.it";
             wallabagServerVersion = 2;
 
             tryPossibleURLs = false;

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,7 +24,7 @@
     <string name="ttsPlayPause">Wiedergabe / Pause</string>
     <string name="ttsFastForward">Rücklauf</string>
     <string name="ttsOptions">Optionen</string>
-    <string name="menu_open_random_article">Zufälligen Artikel öffnen</string>    
+    <string name="menu_open_random_article">Zufälligen Artikel öffnen</string>
     <string name="d_deleteArticle_title">Artikel entfernen?</string>
     <string name="d_deleteArticle_message">Möchtest du den Artikel wirklich entfernen?</string>
     <string name="txtNetOffline">Prüfe deine Internetverbindung!</string>
@@ -127,7 +127,7 @@
     <string name="connectionWizard_providerSelection_provider_general_name">Anderer</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Wähle diese Option, wenn du einen Account auf https://framabag.org hast</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Wähle diese Option, um die Einstellungen manuell einzugeben</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Wähle diese Option, wenn du einen Account auf https://v2.wallabag.org hast</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Wähle diese Option, wenn du einen Account auf https://www.wallabag.it hast</string>
     <string name="connectionWizard_providerSelection_titleMessage">Wähle deinen wallabag Anbieter</string>
     <string name="connectionWizard_provider_framabag_next">Verbinden</string>
     <string name="connectionWizard_provider_framabag_prev">Zurück</string>
@@ -137,7 +137,7 @@
     <string name="connectionWizard_provider_general_titleMessage">Grundlegende Einstellungen</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Verbinden</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Zurück</string>
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">v2.wallabag.org Einstellungen</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">wallabag.it Einstellungen</string>
     <string name="connectionWizard_summary_next">Einstellungen speichern</string>
     <string name="connectionWizard_summary_prev">Zurück</string>
     <string name="connectionWizard_summary_text">Einstellungen speichern und zum Hauptbildschirm gelangen.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -127,7 +127,7 @@
     <string name="connectionWizard_providerSelection_provider_general_name">Anderer</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Wähle diese Option, wenn du einen Account auf https://framabag.org hast</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Wähle diese Option, um die Einstellungen manuell einzugeben</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Wähle diese Option, wenn du einen Account auf https://www.wallabag.it hast</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Wähle diese Option, wenn du einen Account auf https://app.wallabag.it hast</string>
     <string name="connectionWizard_providerSelection_titleMessage">Wähle deinen wallabag Anbieter</string>
     <string name="connectionWizard_provider_framabag_next">Verbinden</string>
     <string name="connectionWizard_provider_framabag_prev">Zurück</string>
@@ -137,7 +137,7 @@
     <string name="connectionWizard_provider_general_titleMessage">Grundlegende Einstellungen</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Verbinden</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Zurück</string>
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">wallabag.it Einstellungen</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">app.wallabag.it Einstellungen</string>
     <string name="connectionWizard_summary_next">Einstellungen speichern</string>
     <string name="connectionWizard_summary_prev">Zurück</string>
     <string name="connectionWizard_summary_text">Einstellungen speichern und zum Hauptbildschirm gelangen.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -217,7 +217,7 @@
     <string name="connectionWizard_providerSelection_titleMessage">Selecciona un proveedor de wallabag</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Otro</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Selecciona esta opción para introducir los ajustes requeridos manualmente</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Selecciona esta opción si tienes una cuenta en https://v2.wallabag.org</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Selecciona esta opción si tienes una cuenta en https://www.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Selecciona esta opción si tienes una cuenta en https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Saltar</string>
     <string name="connectionWizard_providerSelection_next">Siguiente</string>
@@ -226,7 +226,7 @@
     <string name="connectionWizard_provider_general_prev">Volver</string>
     <string name="connectionWizard_provider_general_next">Conectar</string>
 
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuración para v2.wallabag.org</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuración para wallabag.it</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Volver</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Conectar</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -217,7 +217,7 @@
     <string name="connectionWizard_providerSelection_titleMessage">Selecciona un proveedor de wallabag</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Otro</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Selecciona esta opción para introducir los ajustes requeridos manualmente</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Selecciona esta opción si tienes una cuenta en https://www.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Selecciona esta opción si tienes una cuenta en https://app.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Selecciona esta opción si tienes una cuenta en https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Saltar</string>
     <string name="connectionWizard_providerSelection_next">Siguiente</string>
@@ -226,7 +226,7 @@
     <string name="connectionWizard_provider_general_prev">Volver</string>
     <string name="connectionWizard_provider_general_next">Conectar</string>
 
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuración para wallabag.it</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuración para app.wallabag.it</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Volver</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Conectar</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -125,7 +125,7 @@
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Choisissez cette option si vous avez un compte sur https://framabag.org</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Choisissez cette option pour entrer les paramètres requis manuellement</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Autre</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Choisissez cette option si vous avez un compte sur https://www.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Choisissez cette option si vous avez un compte sur https://app.wallabag.it</string>
     <string name="connectionWizard_providerSelection_titleMessage">Choisissez votre fournisseur de wallabag</string>
     <string name="connectionWizard_provider_framabag_next">Connecter</string>
     <string name="connectionWizard_provider_framabag_prev">Retour</string>
@@ -135,7 +135,7 @@
     <string name="connectionWizard_provider_general_titleMessage">Configuration de base</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Connecter</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Retour</string>
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuration de wallabag.it</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuration de app.wallabag.it</string>
     <string name="connectionWizard_summary_next">Sauvegarder les paramètres</string>
     <string name="connectionWizard_summary_prev">Retour</string>
     <string name="connectionWizard_summary_text">Appuyez sur le bouton pour sauvegarder les paramètres et aller à l\'écran principal.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -125,7 +125,7 @@
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Choisissez cette option si vous avez un compte sur https://framabag.org</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Choisissez cette option pour entrer les paramètres requis manuellement</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Autre</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Choisissez cette option si vous avez un compte sur https://v2.wallabag.org</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Choisissez cette option si vous avez un compte sur https://www.wallabag.it</string>
     <string name="connectionWizard_providerSelection_titleMessage">Choisissez votre fournisseur de wallabag</string>
     <string name="connectionWizard_provider_framabag_next">Connecter</string>
     <string name="connectionWizard_provider_framabag_prev">Retour</string>
@@ -135,7 +135,7 @@
     <string name="connectionWizard_provider_general_titleMessage">Configuration de base</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Connecter</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Retour</string>
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuration de v2.wallabag.org</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuration de wallabag.it</string>
     <string name="connectionWizard_summary_next">Sauvegarder les paramètres</string>
     <string name="connectionWizard_summary_prev">Retour</string>
     <string name="connectionWizard_summary_text">Appuyez sur le bouton pour sauvegarder les paramètres et aller à l\'écran principal.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -205,7 +205,7 @@
     <string name="connectionWizard_providerSelection_titleMessage">Выберите поставщика wallabag</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Другой</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Выберите этот вариант для ввода необходимых параметров вручную</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Выберите этот вариант, если у вас есть аккаунт на https://www.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Выберите этот вариант, если у вас есть аккаунт на https://app.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Выберите этот вариант, если у вас есть аккаунт на https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Пропустить</string>
     <string name="connectionWizard_providerSelection_next">Дальше</string>
@@ -214,7 +214,7 @@
     <string name="connectionWizard_provider_general_prev">Назад</string>
     <string name="connectionWizard_provider_general_next">Подключиться</string>
 
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Настройка wallabag.it</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Настройка app.wallabag.it</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Назад</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Подключиться</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -205,7 +205,7 @@
     <string name="connectionWizard_providerSelection_titleMessage">Выберите поставщика wallabag</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Другой</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Выберите этот вариант для ввода необходимых параметров вручную</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Выберите этот вариант, если у вас есть аккаунт на https://v2.wallabag.org</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Выберите этот вариант, если у вас есть аккаунт на https://www.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Выберите этот вариант, если у вас есть аккаунт на https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Пропустить</string>
     <string name="connectionWizard_providerSelection_next">Дальше</string>
@@ -214,7 +214,7 @@
     <string name="connectionWizard_provider_general_prev">Назад</string>
     <string name="connectionWizard_provider_general_next">Подключиться</string>
 
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Настройка v2.wallabag.org</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Настройка wallabag.it</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Назад</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Подключиться</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,9 +218,9 @@
 
     <string name="connectionWizard_providerSelection_titleMessage">Select wallabag provider</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Other</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_name" translatable="false">v2.wallabag.org</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_name" translatable="false">wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Select this option to input required settings manually</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Select this option if you have an account on https://v2.wallabag.org</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Select this option if you have an account on https://www.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_name" translatable="false">Framabag.org</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Select this option if you have an account on https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Skip</string>
@@ -230,7 +230,7 @@
     <string name="connectionWizard_provider_general_prev">Back</string>
     <string name="connectionWizard_provider_general_next">Connect</string>
 
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">v2.wallabag.org configuration</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">wallabag.it configuration</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Back</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Connect</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,9 +218,9 @@
 
     <string name="connectionWizard_providerSelection_titleMessage">Select wallabag provider</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Other</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_name" translatable="false">wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_name" translatable="false">app.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Select this option to input required settings manually</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Select this option if you have an account on https://www.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Select this option if you have an account on https://app.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_name" translatable="false">Framabag.org</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Select this option if you have an account on https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Skip</string>
@@ -230,7 +230,7 @@
     <string name="connectionWizard_provider_general_prev">Back</string>
     <string name="connectionWizard_provider_general_next">Connect</string>
 
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">wallabag.it configuration</string>
+    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">app.wallabag.it configuration</string>
     <string name="connectionWizard_provider_v2wallabagorg_prev">Back</string>
     <string name="connectionWizard_provider_v2wallabagorg_next">Connect</string>
 


### PR DESCRIPTION
v2.wallabag.org will be closed in next days. We need to replace the URL in the android application. 