### PR TITLE
Replace all v2.wallabag.org mentions

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
@@ -47,7 +47,7 @@ public class ConnectionWizardActivity extends AppCompatActivity {
     private static final String DATA_FEEDS_TOKEN = "feeds_token";
 
     private static final int PROVIDER_NO = -1;
-    private static final int PROVIDER_V2_WALLABAG_ORG = 0;
+    private static final int PROVIDER_WALLABAG_IT = 0;
     private static final int PROVIDER_FRAMABAG = 1;
 
     private static final String PAGE_NONE = "";
@@ -55,7 +55,7 @@ public class ConnectionWizardActivity extends AppCompatActivity {
     private static final String PAGE_PROVIDER_SELECTION = "provider_selection";
     private static final String PAGE_CONFIG_GENERIC = "config_generic";
     private static final String PAGE_CONFIG_FRAMABAG = "config_framabag";
-    private static final String PAGE_CONFIG_V2_WALLABAG_ORG = "config_v2_wallabag_org";
+    private static final String PAGE_CONFIG_WALLABAG_IT = "config_wallabag_it";
     private static final String PAGE_SUMMARY = "summary";
 
     public static void runWizard(Context context, boolean skipWelcome) {
@@ -169,8 +169,8 @@ public class ConnectionWizardActivity extends AppCompatActivity {
             case PAGE_PROVIDER_SELECTION:
                 int provider = bundle.getInt(DATA_PROVIDER, PROVIDER_NO);
                 switch(provider) {
-                    case PROVIDER_V2_WALLABAG_ORG:
-                        goToFragment = new V2WallabagOrgConfigFragment();
+                    case PROVIDER_WALLABAG_IT:
+                        goToFragment = new WallabagItConfigFragment();
                         break;
 
                     case PROVIDER_FRAMABAG:
@@ -185,7 +185,7 @@ public class ConnectionWizardActivity extends AppCompatActivity {
 
             case PAGE_CONFIG_GENERIC:
             case PAGE_CONFIG_FRAMABAG:
-            case PAGE_CONFIG_V2_WALLABAG_ORG:
+            case PAGE_CONFIG_WALLABAG_IT:
                 goToFragment = new SummaryFragment();
                 break;
 
@@ -314,8 +314,8 @@ public class ConnectionWizardActivity extends AppCompatActivity {
                 RadioGroup radioGroup = (RadioGroup)view.findViewById(R.id.providerRadioGroup);
                 int provider;
                 switch(radioGroup.getCheckedRadioButtonId()) {
-                    case R.id.providerV2WallabagOrg:
-                        provider = PROVIDER_V2_WALLABAG_ORG;
+                    case R.id.providerWallabagIt:
+                        provider = PROVIDER_WALLABAG_IT;
                         break;
 
                     case R.id.providerFramabag:
@@ -467,15 +467,15 @@ public class ConnectionWizardActivity extends AppCompatActivity {
 
     }
 
-    public static class V2WallabagOrgConfigFragment extends GenericConfigFragment {
+    public static class WallabagItConfigFragment extends GenericConfigFragment {
 
         public String getPageName() {
-            return PAGE_CONFIG_V2_WALLABAG_ORG;
+            return PAGE_CONFIG_WALLABAG_IT;
         }
 
         @Override
         protected int getLayoutResourceID() {
-            return R.layout.connection_wizard_v2wallabagorg_config_fragment;
+            return R.layout.connection_wizard_wallabagit_config_fragment;
         }
 
         @Override

--- a/app/src/main/res/layout/connection_wizard_provider_selection_fragment.xml
+++ b/app/src/main/res/layout/connection_wizard_provider_selection_fragment.xml
@@ -32,15 +32,15 @@
                 android:layout_height="wrap_content" >
 
                 <RadioButton
-                    android:id="@+id/providerV2WallabagOrg"
+                    android:id="@+id/providerWallabagIt"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/connectionWizard_providerSelection_provider_v2wallabagorg_name"
+                    android:text="@string/connectionWizard_providerSelection_provider_wallabagit_name"
                     android:checked="true" />
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/connectionWizard_providerSelection_provider_v2wallabagorg_desc" />
+                    android:text="@string/connectionWizard_providerSelection_provider_wallabagit_desc" />
 
                 <RadioButton
                     android:id="@+id/providerFramabag"

--- a/app/src/main/res/layout/connection_wizard_wallabagit_config_fragment.xml
+++ b/app/src/main/res/layout/connection_wizard_wallabagit_config_fragment.xml
@@ -34,7 +34,7 @@
                 android:gravity="center_horizontal"
                 android:textAppearance="?android:attr/textAppearanceLarge"
                 android:textColor="?android:attr/textColorPrimary"
-                android:text="@string/connectionWizard_provider_v2wallabagorg_titleMessage"/>
+                android:text="@string/connectionWizard_provider_wallabagit_titleMessage"/>
 
             <android.support.design.widget.TextInputLayout
                 android:layout_width="match_parent"
@@ -81,7 +81,7 @@
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:text="@string/connectionWizard_provider_v2wallabagorg_prev" />
+            android:text="@string/connectionWizard_provider_wallabagit_prev" />
 
         <View android:layout_width="1dp"
             android:layout_height="fill_parent"
@@ -93,7 +93,7 @@
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
-            android:text="@string/connectionWizard_provider_v2wallabagorg_next" />
+            android:text="@string/connectionWizard_provider_wallabagit_next" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -125,9 +125,9 @@
     <string name="connectionWizard_providerSelection_next">Weiter</string>
     <string name="connectionWizard_providerSelection_prev">Überspringen</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Anderer</string>
-    <string name="connectionWizard_providerSelection_provider_framabag_desc">Wähle diese Option, wenn du einen Account auf https://framabag.org hast</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Wähle diese Option, um die Einstellungen manuell einzugeben</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Wähle diese Option, wenn du einen Account auf https://app.wallabag.it hast</string>
+    <string name="connectionWizard_providerSelection_provider_framabag_desc">Wähle diese Option, wenn du einen Account auf https://framabag.org hast</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Wähle diese Option, wenn du einen Account auf https://app.wallabag.it hast</string>
     <string name="connectionWizard_providerSelection_titleMessage">Wähle deinen wallabag Anbieter</string>
     <string name="connectionWizard_provider_framabag_next">Verbinden</string>
     <string name="connectionWizard_provider_framabag_prev">Zurück</string>
@@ -135,9 +135,9 @@
     <string name="connectionWizard_provider_general_next">Verbinden</string>
     <string name="connectionWizard_provider_general_prev">Zurück</string>
     <string name="connectionWizard_provider_general_titleMessage">Grundlegende Einstellungen</string>
-    <string name="connectionWizard_provider_v2wallabagorg_next">Verbinden</string>
-    <string name="connectionWizard_provider_v2wallabagorg_prev">Zurück</string>
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">app.wallabag.it Einstellungen</string>
+    <string name="connectionWizard_provider_wallabagit_next">Verbinden</string>
+    <string name="connectionWizard_provider_wallabagit_prev">Zurück</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">app.wallabag.it Einstellungen</string>
     <string name="connectionWizard_summary_next">Einstellungen speichern</string>
     <string name="connectionWizard_summary_prev">Zurück</string>
     <string name="connectionWizard_summary_text">Einstellungen speichern und zum Hauptbildschirm gelangen.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -127,7 +127,7 @@
     <string name="connectionWizard_providerSelection_provider_general_name">Anderer</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Wähle diese Option, um die Einstellungen manuell einzugeben</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Wähle diese Option, wenn du einen Account auf https://framabag.org hast</string>
-    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Wähle diese Option, wenn du einen Account auf https://app.wallabag.it hast</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Wähle diese Option, wenn du einen Account auf https://wallabag.it hast</string>
     <string name="connectionWizard_providerSelection_titleMessage">Wähle deinen wallabag Anbieter</string>
     <string name="connectionWizard_provider_framabag_next">Verbinden</string>
     <string name="connectionWizard_provider_framabag_prev">Zurück</string>
@@ -137,7 +137,7 @@
     <string name="connectionWizard_provider_general_titleMessage">Grundlegende Einstellungen</string>
     <string name="connectionWizard_provider_wallabagit_next">Verbinden</string>
     <string name="connectionWizard_provider_wallabagit_prev">Zurück</string>
-    <string name="connectionWizard_provider_wallabagit_titleMessage">app.wallabag.it Einstellungen</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">wallabag.it Einstellungen</string>
     <string name="connectionWizard_summary_next">Einstellungen speichern</string>
     <string name="connectionWizard_summary_prev">Zurück</string>
     <string name="connectionWizard_summary_text">Einstellungen speichern und zum Hauptbildschirm gelangen.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -217,7 +217,7 @@
     <string name="connectionWizard_providerSelection_titleMessage">Selecciona un proveedor de wallabag</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Otro</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Selecciona esta opción para introducir los ajustes requeridos manualmente</string>
-    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Selecciona esta opción si tienes una cuenta en https://app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Selecciona esta opción si tienes una cuenta en https://wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Selecciona esta opción si tienes una cuenta en https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Saltar</string>
     <string name="connectionWizard_providerSelection_next">Siguiente</string>
@@ -226,7 +226,7 @@
     <string name="connectionWizard_provider_general_prev">Volver</string>
     <string name="connectionWizard_provider_general_next">Conectar</string>
 
-    <string name="connectionWizard_provider_wallabagit_titleMessage">Configuración para app.wallabag.it</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">Configuración para wallabag.it</string>
     <string name="connectionWizard_provider_wallabagit_prev">Volver</string>
     <string name="connectionWizard_provider_wallabagit_next">Conectar</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -217,7 +217,7 @@
     <string name="connectionWizard_providerSelection_titleMessage">Selecciona un proveedor de wallabag</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Otro</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Selecciona esta opción para introducir los ajustes requeridos manualmente</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Selecciona esta opción si tienes una cuenta en https://app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Selecciona esta opción si tienes una cuenta en https://app.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Selecciona esta opción si tienes una cuenta en https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Saltar</string>
     <string name="connectionWizard_providerSelection_next">Siguiente</string>
@@ -226,9 +226,9 @@
     <string name="connectionWizard_provider_general_prev">Volver</string>
     <string name="connectionWizard_provider_general_next">Conectar</string>
 
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuración para app.wallabag.it</string>
-    <string name="connectionWizard_provider_v2wallabagorg_prev">Volver</string>
-    <string name="connectionWizard_provider_v2wallabagorg_next">Conectar</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">Configuración para app.wallabag.it</string>
+    <string name="connectionWizard_provider_wallabagit_prev">Volver</string>
+    <string name="connectionWizard_provider_wallabagit_next">Conectar</string>
 
     <string name="connectionWizard_provider_framabag_titleMessage">Configuración para Framabag</string>
     <string name="connectionWizard_provider_framabag_prev">Volver</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -122,10 +122,10 @@
     <string name="checkFeeds_progressDialogMessage">Vérification des flux…</string>
     <string name="connectionWizard_providerSelection_next">Suivant</string>
     <string name="connectionWizard_providerSelection_prev">Ignorer</string>
-    <string name="connectionWizard_providerSelection_provider_framabag_desc">Choisissez cette option si vous avez un compte sur https://framabag.org</string>
-    <string name="connectionWizard_providerSelection_provider_general_desc">Choisissez cette option pour entrer les paramètres requis manuellement</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Autre</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Choisissez cette option si vous avez un compte sur https://app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_general_desc">Choisissez cette option pour entrer les paramètres requis manuellement</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Choisissez cette option si vous avez un compte sur https://app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_framabag_desc">Choisissez cette option si vous avez un compte sur https://framabag.org</string>
     <string name="connectionWizard_providerSelection_titleMessage">Choisissez votre fournisseur de wallabag</string>
     <string name="connectionWizard_provider_framabag_next">Connecter</string>
     <string name="connectionWizard_provider_framabag_prev">Retour</string>
@@ -133,9 +133,9 @@
     <string name="connectionWizard_provider_general_next">Connecter</string>
     <string name="connectionWizard_provider_general_prev">Retour</string>
     <string name="connectionWizard_provider_general_titleMessage">Configuration de base</string>
-    <string name="connectionWizard_provider_v2wallabagorg_next">Connecter</string>
-    <string name="connectionWizard_provider_v2wallabagorg_prev">Retour</string>
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Configuration de app.wallabag.it</string>
+    <string name="connectionWizard_provider_wallabagit_next">Connecter</string>
+    <string name="connectionWizard_provider_wallabagit_prev">Retour</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">Configuration de app.wallabag.it</string>
     <string name="connectionWizard_summary_next">Sauvegarder les paramètres</string>
     <string name="connectionWizard_summary_prev">Retour</string>
     <string name="connectionWizard_summary_text">Appuyez sur le bouton pour sauvegarder les paramètres et aller à l\'écran principal.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -124,7 +124,7 @@
     <string name="connectionWizard_providerSelection_prev">Ignorer</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Autre</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Choisissez cette option pour entrer les paramètres requis manuellement</string>
-    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Choisissez cette option si vous avez un compte sur https://app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Choisissez cette option si vous avez un compte sur https://wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Choisissez cette option si vous avez un compte sur https://framabag.org</string>
     <string name="connectionWizard_providerSelection_titleMessage">Choisissez votre fournisseur de wallabag</string>
     <string name="connectionWizard_provider_framabag_next">Connecter</string>
@@ -135,7 +135,7 @@
     <string name="connectionWizard_provider_general_titleMessage">Configuration de base</string>
     <string name="connectionWizard_provider_wallabagit_next">Connecter</string>
     <string name="connectionWizard_provider_wallabagit_prev">Retour</string>
-    <string name="connectionWizard_provider_wallabagit_titleMessage">Configuration de app.wallabag.it</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">Configuration de wallabag.it</string>
     <string name="connectionWizard_summary_next">Sauvegarder les paramètres</string>
     <string name="connectionWizard_summary_prev">Retour</string>
     <string name="connectionWizard_summary_text">Appuyez sur le bouton pour sauvegarder les paramètres et aller à l\'écran principal.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -205,7 +205,7 @@
     <string name="connectionWizard_providerSelection_titleMessage">Выберите поставщика wallabag</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Другой</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Выберите этот вариант для ввода необходимых параметров вручную</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Выберите этот вариант, если у вас есть аккаунт на https://app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Выберите этот вариант, если у вас есть аккаунт на https://app.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Выберите этот вариант, если у вас есть аккаунт на https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Пропустить</string>
     <string name="connectionWizard_providerSelection_next">Дальше</string>
@@ -214,9 +214,9 @@
     <string name="connectionWizard_provider_general_prev">Назад</string>
     <string name="connectionWizard_provider_general_next">Подключиться</string>
 
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">Настройка app.wallabag.it</string>
-    <string name="connectionWizard_provider_v2wallabagorg_prev">Назад</string>
-    <string name="connectionWizard_provider_v2wallabagorg_next">Подключиться</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">Настройка app.wallabag.it</string>
+    <string name="connectionWizard_provider_wallabagit_prev">Назад</string>
+    <string name="connectionWizard_provider_wallabagit_next">Подключиться</string>
 
     <string name="connectionWizard_provider_framabag_titleMessage">Настройка Framabag</string>
     <string name="connectionWizard_provider_framabag_prev">Назад</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -205,7 +205,7 @@
     <string name="connectionWizard_providerSelection_titleMessage">Выберите поставщика wallabag</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Другой</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Выберите этот вариант для ввода необходимых параметров вручную</string>
-    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Выберите этот вариант, если у вас есть аккаунт на https://app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Выберите этот вариант, если у вас есть аккаунт на https://wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Выберите этот вариант, если у вас есть аккаунт на https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Пропустить</string>
     <string name="connectionWizard_providerSelection_next">Дальше</string>
@@ -214,7 +214,7 @@
     <string name="connectionWizard_provider_general_prev">Назад</string>
     <string name="connectionWizard_provider_general_next">Подключиться</string>
 
-    <string name="connectionWizard_provider_wallabagit_titleMessage">Настройка app.wallabag.it</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">Настройка wallabag.it</string>
     <string name="connectionWizard_provider_wallabagit_prev">Назад</string>
     <string name="connectionWizard_provider_wallabagit_next">Подключиться</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,9 +218,9 @@
 
     <string name="connectionWizard_providerSelection_titleMessage">Select wallabag provider</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Other</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_name" translatable="false">app.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Select this option to input required settings manually</string>
-    <string name="connectionWizard_providerSelection_provider_v2wallabagorg_desc">Select this option if you have an account on https://app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_name" translatable="false">app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Select this option if you have an account on https://app.wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_name" translatable="false">Framabag.org</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Select this option if you have an account on https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Skip</string>
@@ -230,9 +230,9 @@
     <string name="connectionWizard_provider_general_prev">Back</string>
     <string name="connectionWizard_provider_general_next">Connect</string>
 
-    <string name="connectionWizard_provider_v2wallabagorg_titleMessage">app.wallabag.it configuration</string>
-    <string name="connectionWizard_provider_v2wallabagorg_prev">Back</string>
-    <string name="connectionWizard_provider_v2wallabagorg_next">Connect</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">app.wallabag.it configuration</string>
+    <string name="connectionWizard_provider_wallabagit_prev">Back</string>
+    <string name="connectionWizard_provider_wallabagit_next">Connect</string>
 
     <string name="connectionWizard_provider_framabag_titleMessage">Framabag configuration</string>
     <string name="connectionWizard_provider_framabag_prev">Back</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,8 +219,8 @@
     <string name="connectionWizard_providerSelection_titleMessage">Select wallabag provider</string>
     <string name="connectionWizard_providerSelection_provider_general_name">Other</string>
     <string name="connectionWizard_providerSelection_provider_general_desc">Select this option to input required settings manually</string>
-    <string name="connectionWizard_providerSelection_provider_wallabagit_name" translatable="false">app.wallabag.it</string>
-    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Select this option if you have an account on https://app.wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_name" translatable="false">wallabag.it</string>
+    <string name="connectionWizard_providerSelection_provider_wallabagit_desc">Select this option if you have an account on https://wallabag.it</string>
     <string name="connectionWizard_providerSelection_provider_framabag_name" translatable="false">Framabag.org</string>
     <string name="connectionWizard_providerSelection_provider_framabag_desc">Select this option if you have an account on https://framabag.org</string>
     <string name="connectionWizard_providerSelection_prev">Skip</string>
@@ -230,7 +230,7 @@
     <string name="connectionWizard_provider_general_prev">Back</string>
     <string name="connectionWizard_provider_general_next">Connect</string>
 
-    <string name="connectionWizard_provider_wallabagit_titleMessage">app.wallabag.it configuration</string>
+    <string name="connectionWizard_provider_wallabagit_titleMessage">wallabag.it configuration</string>
     <string name="connectionWizard_provider_wallabagit_prev">Back</string>
     <string name="connectionWizard_provider_wallabagit_next">Connect</string>
 


### PR DESCRIPTION
A follow-up to #365.

Also replace "app.wallabag.it" with "wallabag.it" in display-only strings. Users don't care about the "app." part, do they?

cc @nicosomb 