### PR TITLE
Don't stuck on deleted articles

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/exceptions/UnsuccessfulResponseException.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/exceptions/UnsuccessfulResponseException.java
@@ -1,0 +1,37 @@
+package fr.gaulupeau.apps.Poche.network.exceptions;
+
+public class UnsuccessfulResponseException extends RequestException {
+
+    private int responseCode;
+    private String responseMessage;
+    private String responseBody;
+    private String url;
+
+    public UnsuccessfulResponseException(int responseCode,
+                                         String responseMessage,
+                                         String responseBody,
+                                         String url) {
+        super("HTTP "+ responseCode + ": " + responseMessage + ". Requested for URL: " + url);
+        this.responseCode = responseCode;
+        this.responseMessage = responseMessage;
+        this.responseBody = responseBody;
+        this.url = url;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    public String getResponseMessage() {
+        return responseMessage;
+    }
+
+    public String getResponseBody() {
+        return responseBody;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+}


### PR DESCRIPTION
If article related actions (mark as favorite/archived, delete) fail because of HTTP 404, consider the action as successful.

v1.9 endpoint seems to be unaffected by the issue.

Fixes #319 #375.