### PR TITLE
change default theme to dark

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -368,7 +368,7 @@ public class Settings {
             } catch(IllegalArgumentException ignored) {}
         }
 
-        return theme != null ? theme : Themes.Theme.Light;
+        return theme != null ? theme : Themes.Theme.Dark;
     }
 
     public void setTheme(Themes.Theme theme) {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -78,7 +78,7 @@
             android:key="@string/pref_key_ui_theme"
             android:title="@string/pref_name_ui_theme"
             android:dialogTitle="@string/pref_name_ui_theme"
-            android:defaultValue="Light" />
+            android:defaultValue="Dark" />
         <fr.gaulupeau.apps.Poche.ui.preferences.IntEditTextPreference
             android:key="@string/pref_key_ui_article_fontSize"
             android:title="@string/pref_name_ui_article_fontSize"


### PR DESCRIPTION
My suggestion is to change the default theme to dark. I know two friends using the app in dark theme and i am using the dark theme, too. But i do not know if this is common usage. It looks much better and is not too bright for the eyes. Therefore i would choose to change the default.

What do you think?
