### PR TITLE
Fix default theme name (to match enum)

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -78,7 +78,7 @@
             android:key="@string/pref_key_ui_theme"
             android:title="@string/pref_name_ui_theme"
             android:dialogTitle="@string/pref_name_ui_theme"
-            android:defaultValue="Light" />
+            android:defaultValue="LIGHT" />
         <fr.gaulupeau.apps.Poche.ui.preferences.IntEditTextPreference
             android:key="@string/pref_key_ui_article_fontSize"
             android:title="@string/pref_name_ui_article_fontSize"


### PR DESCRIPTION
I knew I forgot something...

(It worked anyway, because there is a try-catch block with a fallback to `Light` theme).