### PR TITLE
Update lists

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data android:name="android.app.searchable"
+                       android:resource="@xml/searchable" />
         </activity>
         <activity
             android:name="fr.gaulupeau.apps.Poche.ui.ReadArticleActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         <activity android:name="fr.gaulupeau.apps.Poche.ui.ArticlesListActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.SEARCH" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/LegacySettingsHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/LegacySettingsHelper.java
@@ -17,7 +17,6 @@ class LegacySettingsHelper {
     static final String CUSTOM_SSL_SETTINGS = "custom_ssl_settings";
     static final String FONT_SIZE = "font_size";
     static final String SERIF_FONT = "serif_font";
-    static final String LIST_LIMIT = "list_limit";
     static final String USERNAME = "username";
     static final String PASSWORD = "password";
     static final String HTTP_AUTH_USERNAME = "http_auth_username";
@@ -73,8 +72,6 @@ class LegacySettingsHelper {
             prefEditor.putInt(cx.getString(R.string.pref_key_ui_article_fontSize), fontSize);
         }
         migrateBooleanPref(cx, SERIF_FONT, R.string.pref_key_ui_article_fontSerif, legacyPref, prefEditor);
-
-        migrateIntPref(cx, LIST_LIMIT, R.string.pref_key_ui_lists_limit, legacyPref, prefEditor, 50);
 
         migrateStringPref(cx, THEME, R.string.pref_key_ui_theme, legacyPref, prefEditor);
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -18,6 +18,7 @@ import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.App;
 import fr.gaulupeau.apps.Poche.network.ConnectivityChangeReceiver;
 import fr.gaulupeau.apps.Poche.service.WallabagJobService;
+import fr.gaulupeau.apps.Poche.ui.ArticlesListFragment;
 import fr.gaulupeau.apps.Poche.ui.HttpSchemeHandlerActivity;
 import fr.gaulupeau.apps.Poche.ui.Themes;
 import fr.gaulupeau.apps.Poche.ui.preferences.ConnectionWizardActivity;
@@ -348,6 +349,23 @@ public class Settings {
 
     public void setArticleFontSerif(boolean value) {
         setBoolean(R.string.pref_key_ui_article_fontSerif, value);
+    }
+
+    public ArticlesListFragment.SortOrder getListSortOrder() {
+        String sortOrderParam = getString(R.string.pref_key_ui_lists_sortOrder);
+
+        ArticlesListFragment.SortOrder sortOrder = null;
+        if(sortOrderParam != null) {
+            try {
+                sortOrder = ArticlesListFragment.SortOrder.valueOf(sortOrderParam);
+            } catch(IllegalArgumentException ignored) {}
+        }
+
+        return sortOrder != null ? sortOrder : ArticlesListFragment.SortOrder.DESC;
+    }
+
+    public void setListSortOrder(ArticlesListFragment.SortOrder sortOrder) {
+        setString(R.string.pref_key_ui_lists_sortOrder, sortOrder.toString());
     }
 
     public Themes.Theme getTheme() {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -350,14 +350,6 @@ public class Settings {
         setBoolean(R.string.pref_key_ui_article_fontSerif, value);
     }
 
-    public int getArticlesListLimit() {
-        return getInt(R.string.pref_key_ui_lists_limit, 100);
-    }
-
-    public void setArticlesListLimit(int limit) {
-        setInt(R.string.pref_key_ui_lists_limit, limit);
-    }
-
     public Themes.Theme getTheme() {
         String themeName = getString(R.string.pref_key_ui_theme);
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
@@ -395,19 +395,27 @@ public class ArticlesListActivity extends AppCompatActivity
     }
 
     private void updateAllLists() {
+        Log.d(TAG, "updateAllLists() started");
+
         for(int i = 0; i < ArticlesListPagerAdapter.PAGES.length; i++) {
             ArticlesListFragment f = getFragment(i);
             if(f != null) {
                 f.updateList();
+            } else {
+                Log.w(TAG, "updateAllLists() fragment is null; position: " + i);
             }
         }
     }
 
     private void updateList(int position) {
+        Log.d(TAG, "updateList() position: " + position);
+
         if(position != -1) {
             ArticlesListFragment f = getFragment(position);
             if(f != null) {
                 f.updateList();
+            } else {
+                Log.w(TAG, "updateList() fragment is null");
             }
         } else {
             updateAllLists();

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
@@ -80,7 +80,8 @@ public class ArticlesListActivity extends AppCompatActivity
 
         settings = new Settings(this);
 
-        adapter = new ArticlesListPagerAdapter(getSupportFragmentManager());
+        adapter = new ArticlesListPagerAdapter(
+                getSupportFragmentManager(), savedInstanceState != null);
 
         viewPager = (ViewPager) findViewById(R.id.articles_list_pager);
         viewPager.setAdapter(adapter);
@@ -557,8 +558,28 @@ public class ArticlesListActivity extends AppCompatActivity
 
         private ArticlesListFragment[] fragments = new ArticlesListFragment[PAGES.length];
 
-        public ArticlesListPagerAdapter(FragmentManager fm) {
+        public ArticlesListPagerAdapter(FragmentManager fm, boolean tryToRestoreFragments) {
             super(fm);
+
+            if(tryToRestoreFragments) {
+                Log.d(TAG, "<init>() trying to restore fragments");
+
+                for(Fragment f: fm.getFragments()) {
+                    if(f instanceof ArticlesListFragment) {
+                        ArticlesListFragment articlesListFragment = (ArticlesListFragment)f;
+                        Log.d(TAG, "<init>() found fragment of type: "
+                                + articlesListFragment.getListType());
+
+                        for(int i = 0; i < PAGES.length; i++) {
+                            if(articlesListFragment.getListType() == PAGES[i]) {
+                                fragments[i] = articlesListFragment;
+
+                                Log.d(TAG, "<init>() restored fragment at position: " + i);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         @Override

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
@@ -67,7 +67,7 @@ public class ArticlesListActivity extends AppCompatActivity
 
     private boolean updateRunning;
 
-    private ArticlesListFragment.SortOrder sortOrder = ArticlesListFragment.SortOrder.DESC;
+    private ArticlesListFragment.SortOrder sortOrder;
     private String searchString;
 
     private ConfigurationTestHelper configurationTestHelper;
@@ -93,6 +93,8 @@ public class ArticlesListActivity extends AppCompatActivity
         firstSyncDone = settings.isFirstSyncDone();
 
         offlineQueuePending = settings.isOfflineQueuePending();
+
+        sortOrder = settings.getListSortOrder();
 
         EventBus.getDefault().register(this);
 
@@ -297,6 +299,8 @@ public class ArticlesListActivity extends AppCompatActivity
         sortOrder = sortOrder == ArticlesListFragment.SortOrder.DESC
                 ? ArticlesListFragment.SortOrder.ASC
                 : ArticlesListFragment.SortOrder.DESC;
+
+        settings.setListSortOrder(sortOrder);
 
         setSortOrder(getCurrentFragment(), sortOrder);
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
@@ -365,6 +365,9 @@ public class ArticlesListActivity extends AppCompatActivity
                 Toast.makeText(this, getString(R.string.txtConfigNotSet), Toast.LENGTH_SHORT).show();
             }
         } else if(WallabagConnection.isNetworkAvailable()) {
+            // sync queue before full update
+            if(feedType == null) ServiceHelper.syncQueue(this);
+
             ServiceHelper.updateFeed(this, feedType, updateType);
 
             result = true;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
@@ -32,7 +32,6 @@ import static fr.gaulupeau.apps.Poche.data.ListTypes.*;
 
 public class ArticlesListFragment extends Fragment implements ListAdapter.OnItemClickListener {
 
-    // TODO: remove logging
     private static final String TAG = ArticlesListFragment.class.getSimpleName();
 
     private static final String LIST_TYPE_PARAM = "list_type";
@@ -118,7 +117,7 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     public void onResume() {
         super.onResume();
 
-        Log.d(TAG, "Fragment " + listType + " onResume()");
+        Log.v(TAG, "Fragment " + listType + " onResume()");
 
         if(firstShown) {
             firstShown = false;
@@ -132,7 +131,7 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     public void onPause() {
         super.onPause();
 
-        Log.d(TAG, "Fragment " + listType + " onPause()");
+        Log.v(TAG, "Fragment " + listType + " onPause()");
 
         if(refreshLayout != null) {
             // http://stackoverflow.com/a/27073879
@@ -146,7 +145,7 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     public void onAttach(Context context) {
         super.onAttach(context);
 
-        Log.d(TAG, "Fragment " + listType + " onAttach()");
+        Log.v(TAG, "Fragment " + listType + " onAttach()");
 
         if(context instanceof OnFragmentInteractionListener) {
             host = (OnFragmentInteractionListener) context;
@@ -157,7 +156,7 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     public void onDetach() {
         super.onDetach();
 
-        Log.d(TAG, "Fragment " + listType + " onDetach()");
+        Log.v(TAG, "Fragment " + listType + " onDetach()");
 
         host = null;
     }
@@ -169,7 +168,7 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     }
 
     public void onShow() {
-        Log.d(TAG, "Fragment " + listType + " onShow()");
+        Log.v(TAG, "Fragment " + listType + " onShow()");
 
         checkRefresh();
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
@@ -41,6 +41,7 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     private static final int PER_PAGE_LIMIT = 30;
 
     private int listType;
+    private String searchString;
 
     private OnFragmentInteractionListener host;
 
@@ -176,6 +177,13 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
         checkRefresh();
     }
 
+    public void setSearchString(String searchString) {
+        String oldSearchString = this.searchString;
+        this.searchString = searchString;
+
+        if(!TextUtils.equals(oldSearchString, searchString)) updateList();
+    }
+
     public void updateList() {
         List<Article> articles = getArticles(0);
 
@@ -265,6 +273,11 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
             default:
                 qb.where(ArticleDao.Properties.Archive.eq(false));
                 break;
+        }
+
+        if(!TextUtils.isEmpty(searchString)) {
+            qb.whereOr(ArticleDao.Properties.Title.like("%" + searchString + "%"),
+                    ArticleDao.Properties.Content.like("%" + searchString + "%"));
         }
 
         qb.orderDesc(ArticleDao.Properties.ArticleId);

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
@@ -245,7 +245,7 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
             qb.offset(PER_PAGE_LIMIT * page);
         }
 
-        return detachArticleObjects(qb.list());
+        return removeContent(detachArticleObjects(qb.list()));
     }
 
     private QueryBuilder<Article> getArticlesQueryBuilder() {
@@ -279,6 +279,15 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     private List<Article> detachArticleObjects(List<Article> articles) {
         for(Article article: articles) {
             mArticleDao.detach(article);
+        }
+
+        return articles;
+    }
+
+    // removes content from article objects in order to free memory
+    private List<Article> removeContent(List<Article> articles) {
+        for(Article article: articles) {
+            article.setContent(null);
         }
 
         return articles;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
@@ -43,13 +43,13 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     private static final String LIST_TYPE_PARAM = "list_type";
 
     private static final String SORT_ORDER_STATE = "sort_order";
-    private static final String SEARCH_STRING_STATE = "search_string";
+    private static final String SEARCH_QUERY_STATE = "search_query";
 
     private static final int PER_PAGE_LIMIT = 30;
 
     private int listType;
     private SortOrder sortOrder = SortOrder.DESC;
-    private String searchString;
+    private String searchQuery;
 
     private OnFragmentInteractionListener host;
 
@@ -91,7 +91,7 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
             Log.v(TAG, "Fragment " + listType + " onCreate() restoring state");
 
             sortOrder = SortOrder.values()[savedInstanceState.getInt(SORT_ORDER_STATE)];
-            searchString = savedInstanceState.getString(SEARCH_STRING_STATE);
+            searchQuery = savedInstanceState.getString(SEARCH_QUERY_STATE);
         }
 
         DaoSession daoSession = DbConnection.getSession();
@@ -188,7 +188,7 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
         Log.v(TAG, "Fragment " + listType + " onSaveInstanceState()");
 
         outState.putInt(SORT_ORDER_STATE, sortOrder.ordinal());
-        outState.putString(SEARCH_STRING_STATE, searchString);
+        outState.putString(SEARCH_QUERY_STATE, searchQuery);
     }
 
     @Override
@@ -208,11 +208,11 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
         if(sortOrder != oldSortOrder) invalidateList();
     }
 
-    public void setSearchString(String searchString) {
-        String oldSearchString = this.searchString;
-        this.searchString = searchString;
+    public void setSearchQuery(String searchQuery) {
+        String oldSearchQuery = this.searchQuery;
+        this.searchQuery = searchQuery;
 
-        if(!TextUtils.equals(oldSearchString, searchString)) invalidateList();
+        if(!TextUtils.equals(oldSearchQuery, searchQuery)) invalidateList();
     }
 
     public void invalidateList() {
@@ -314,9 +314,9 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
                 break;
         }
 
-        if(!TextUtils.isEmpty(searchString)) {
-            qb.whereOr(ArticleDao.Properties.Title.like("%" + searchString + "%"),
-                    ArticleDao.Properties.Content.like("%" + searchString + "%"));
+        if(!TextUtils.isEmpty(searchQuery)) {
+            qb.whereOr(ArticleDao.Properties.Title.like("%" + searchQuery + "%"),
+                    ArticleDao.Properties.Content.like("%" + searchQuery + "%"));
         }
 
         switch(sortOrder) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
@@ -177,6 +177,10 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
         checkRefresh();
     }
 
+    public int getListType() {
+        return listType;
+    }
+
     public void setSearchString(String searchString) {
         String oldSearchString = this.searchString;
         this.searchString = searchString;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListFragment.java
@@ -128,8 +128,6 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
 
             updateList();
         }
-
-        onShow();
     }
 
     public void onPause() {
@@ -169,12 +167,6 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     public void onItemClick(int position) {
         Article article = mArticles.get(position);
         openArticle(article.getId());
-    }
-
-    public void onShow() {
-        Log.v(TAG, "Fragment " + listType + " onShow()");
-
-        checkRefresh();
     }
 
     public int getListType() {
@@ -242,12 +234,6 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
     public void setRefreshingUI(boolean refreshing) {
         if(refreshLayout != null) {
             refreshLayout.setRefreshing(refreshing);
-        }
-    }
-
-    private void checkRefresh() {
-        if(host != null) {
-            setRefreshingUI(host.isFullUpdateRunning() || host.isCurrentFeedUpdating());
         }
     }
 
@@ -361,8 +347,6 @@ public class ArticlesListFragment extends Fragment implements ListAdapter.OnItem
 
     public interface OnFragmentInteractionListener {
         void updateFeed();
-        boolean isFullUpdateRunning();
-        boolean isCurrentFeedUpdating();
     }
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/EndlessRecyclerViewScrollListener.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/EndlessRecyclerViewScrollListener.java
@@ -1,0 +1,111 @@
+package fr.gaulupeau.apps.Poche.ui;
+
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
+
+/**
+ * Sources:
+ * https://gist.github.com/nesquena/d09dc68ff07e845cc622
+ * https://github.com/codepath/android_guides/wiki/Endless-Scrolling-with-AdapterViews-and-RecyclerView
+ */
+public abstract class EndlessRecyclerViewScrollListener extends RecyclerView.OnScrollListener {
+    // The minimum amount of items to have below your current scroll position
+    // before loading more.
+    private int visibleThreshold = 5;
+    // The current offset index of data you have loaded
+    private int currentPage = 0;
+    // The total number of items in the dataset after the last load
+    private int previousTotalItemCount = 0;
+    // True if we are still waiting for the last set of data to load.
+    private boolean loading = true;
+    // Sets the starting page index
+    private int startingPageIndex = 0;
+
+    private RecyclerView.LayoutManager mLayoutManager;
+
+    public EndlessRecyclerViewScrollListener(LinearLayoutManager layoutManager) {
+        this.mLayoutManager = layoutManager;
+    }
+
+    public EndlessRecyclerViewScrollListener(GridLayoutManager layoutManager) {
+        this.mLayoutManager = layoutManager;
+        visibleThreshold = visibleThreshold * layoutManager.getSpanCount();
+    }
+
+    public EndlessRecyclerViewScrollListener(StaggeredGridLayoutManager layoutManager) {
+        this.mLayoutManager = layoutManager;
+        visibleThreshold = visibleThreshold * layoutManager.getSpanCount();
+    }
+
+    private int getLastVisibleItem(int[] lastVisibleItemPositions) {
+        int maxSize = 0;
+        for(int i = 0; i < lastVisibleItemPositions.length; i++) {
+            if(i == 0) {
+                maxSize = lastVisibleItemPositions[i];
+            } else if(lastVisibleItemPositions[i] > maxSize) {
+                maxSize = lastVisibleItemPositions[i];
+            }
+        }
+        return maxSize;
+    }
+
+    // This happens many times a second during a scroll, so be wary of the code you place here.
+    // We are given a few useful parameters to help us work out if we need to load some more data,
+    // but first we check if we are waiting for the previous load to finish.
+    @Override
+    public void onScrolled(RecyclerView view, int dx, int dy) {
+        int lastVisibleItemPosition = 0;
+        int totalItemCount = mLayoutManager.getItemCount();
+
+        if(mLayoutManager instanceof StaggeredGridLayoutManager) {
+            int[] lastVisibleItemPositions = ((StaggeredGridLayoutManager)mLayoutManager)
+                    .findLastVisibleItemPositions(null);
+            // get maximum element within the list
+            lastVisibleItemPosition = getLastVisibleItem(lastVisibleItemPositions);
+        } else if(mLayoutManager instanceof LinearLayoutManager) {
+            lastVisibleItemPosition = ((LinearLayoutManager)mLayoutManager)
+                    .findLastVisibleItemPosition();
+        }
+
+        // If the total item count is zero and the previous isn't, assume the
+        // list is invalidated and should be reset back to initial state
+        if(totalItemCount < previousTotalItemCount) {
+            this.currentPage = this.startingPageIndex;
+            this.previousTotalItemCount = totalItemCount;
+            if(totalItemCount == 0) {
+                this.loading = true;
+            }
+        }
+
+        // If it’s still loading, we check to see if the dataset count has
+        // changed, if so we conclude it has finished loading and update the current page
+        // number and total item count.
+        if(loading && (totalItemCount > previousTotalItemCount)) {
+            loading = false;
+            previousTotalItemCount = totalItemCount;
+        }
+
+        // If it isn’t currently loading, we check to see if we have breached
+        // the visibleThreshold and need to reload more data.
+        // If we do need to reload some more data, we execute onLoadMore to fetch the data.
+        // threshold should reflect how many total columns there are too
+        if(!loading && (lastVisibleItemPosition + visibleThreshold) > totalItemCount) {
+            currentPage++;
+            onLoadMore(currentPage, totalItemCount, view);
+            loading = true;
+        }
+    }
+
+    // Call this method whenever performing new searches
+    public void resetState() {
+        this.currentPage = this.startingPageIndex;
+        this.previousTotalItemCount = 0;
+        this.loading = true;
+    }
+
+    // Defines the process for actually loading more data based on page
+    public abstract void onLoadMore(int page, int totalItemsCount, RecyclerView view);
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -57,7 +57,6 @@ public class SettingsActivity extends AppCompatActivity {
                 R.string.pref_key_connection_advanced_httpAuthPassword,
                 R.string.pref_key_ui_theme,
                 R.string.pref_key_ui_article_fontSize,
-                R.string.pref_key_ui_lists_limit,
                 R.string.pref_key_ui_screenScrolling_percent,
                 R.string.pref_key_autoSync_interval,
                 R.string.pref_key_autoSync_type
@@ -469,7 +468,6 @@ public class SettingsActivity extends AppCompatActivity {
                 case R.string.pref_key_connection_feedsUserID:
                 case R.string.pref_key_connection_advanced_httpAuthUsername:
                 case R.string.pref_key_ui_article_fontSize:
-                case R.string.pref_key_ui_lists_limit:
                 case R.string.pref_key_ui_screenScrolling_percent:
                     setEditTextSummaryFromContent(key);
                     break;

--- a/app/src/main/res/drawable/ic_search_24dp.xml
+++ b/app/src/main/res/drawable/ic_search_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/app/src/main/res/menu/option_list.xml
+++ b/app/src/main/res/menu/option_list.xml
@@ -19,6 +19,8 @@
         app:actionViewClass="android.support.v7.widget.SearchView" />
     <item android:id="@+id/menuSyncQueue"
         android:title="@string/menu_syncLocalChanges" />
+    <item android:id="@+id/menuChangeSortOrder"
+        android:title="@string/menu_lists_changeSortOrder" />
     <item android:id="@+id/menuOpenRandomArticle"
         android:title="@string/menu_open_random_article" />
     <item android:id="@+id/menuSettings"

--- a/app/src/main/res/menu/option_list.xml
+++ b/app/src/main/res/menu/option_list.xml
@@ -11,6 +11,12 @@
         android:title="@string/update_allFeeds"
         android:icon="@drawable/ic_action_refresh"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/menuSearch"
+        android:title="@string/menu_lists_search"
+        android:icon="@drawable/ic_search_24dp"
+        app:showAsAction="collapseActionView|ifRoom"
+        app:actionViewClass="android.support.v7.widget.SearchView" />
     <item android:id="@+id/menuSyncQueue"
         android:title="@string/menu_syncLocalChanges" />
     <item android:id="@+id/menuOpenRandomArticle"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -112,7 +112,6 @@
     <string name="pref_name_ui_article_fontSize">Schriftgröße für Artikel (in %)</string>
     <string name="pref_name_ui_article_fontSerif">Serifen-Schrift</string>
     <string name="pref_desc_ui_article_fontSerif">Serifen-Schrift für Artikel</string>
-    <string name="pref_name_ui_lists_limit">Limit für Artikelliste</string>
 
     <string name="pref_name_misc_handleHttpScheme">HTTP-Schema benutzen</string>
     <string name="pref_desc_misc_handleHttpScheme">Zeige wallabag in der Liste der Webbrowser</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -165,7 +165,6 @@
     <string name="pref_name_ui_article_fontSize">Tamaño de letra del artículo (%)</string>
     <string name="pref_name_ui_article_fontSerif">Tipografía Serif</string>
     <string name="pref_desc_ui_article_fontSerif">Usar tipografía Serif para contenido del artículo</string>
-    <string name="pref_name_ui_lists_limit">Límite de la lista de artículos</string>
     <string name="pref_categoryName_ui_screenScrolling">Desplazamiento de pantalla</string>
     <string name="pref_name_ui_volumeButtonsScrolling_enabled">Desplazar con botones de volumen</string>
     <string name="pref_name_ui_tapToScroll_enabled">Tocar para desplazar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -110,7 +110,6 @@
     <string name="pref_name_ui_theme">Thème de l\'application</string>
     <string name="pref_name_ui_article_fontSize">Taille de la police (%)</string>
     <string name="pref_desc_ui_article_fontSerif">Police avec empattement (serif)</string>
-    <string name="pref_name_ui_lists_limit">Limitation du nombre d\'articles dans la liste</string>
 
     <string name="pref_name_misc_handleHttpScheme">Prendre en charge les URI HTTP</string>
     <string name="pref_desc_misc_handleHttpScheme">Montrer wallabag dans la liste des navigateurs</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -163,7 +163,6 @@
     <string name="pref_name_ui_article_fontSize">記事のフォントサイズ (%)</string>
     <string name="pref_name_ui_article_fontSerif">書体</string>
     <string name="pref_desc_ui_article_fontSerif">記事フォントの書体</string>
-    <string name="pref_name_ui_lists_limit">記事一覧の制限</string>
     <string name="pref_categoryName_ui_screenScrolling">画面のスクロール</string>
     <string name="pref_name_ui_volumeButtonsScrolling_enabled">ボリューム ボタンでスクロール</string>
     <string name="pref_name_ui_tapToScroll_enabled">タップしてスクロール</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -97,7 +97,6 @@
     <string name="pref_name_ui_article_fontSize">Размер шрифта статей (%)</string>
     <string name="pref_name_ui_article_fontSerif">Шрифт с засечками</string>
     <string name="pref_desc_ui_article_fontSerif">Шрифт с засечками для статей</string>
-    <string name="pref_name_ui_lists_limit">Размер списка статей</string>
 
     <string name="pref_name_misc_wipeDB">Очистить базу данных</string>
     <string name="pref_name_misc_wipeDB_confirmTitle">Удалить данные?</string>

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -13,6 +13,7 @@
 
     <string name="pref_key_ui_article_fontSize" translatable="false">ui.article.fontSize</string>
     <string name="pref_key_ui_article_fontSerif" translatable="false">ui.article.fontSerif</string>
+    <string name="pref_key_ui_lists_sortOrder" translatable="false">ui.lists.sortOrder</string>
     <string name="pref_key_ui_theme" translatable="false">ui.theme</string>
     <string name="pref_key_ui_volumeButtonsScrolling_enabled" translatable="false">ui.volumeButtonsScrolling.enabled</string>
     <string name="pref_key_ui_tapToScroll_enabled" translatable="false">ui.tapToScroll.enabled</string>

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -13,7 +13,6 @@
 
     <string name="pref_key_ui_article_fontSize" translatable="false">ui.article.fontSize</string>
     <string name="pref_key_ui_article_fontSerif" translatable="false">ui.article.fontSerif</string>
-    <string name="pref_key_ui_lists_limit" translatable="false">ui.lists.limit</string>
     <string name="pref_key_ui_theme" translatable="false">ui.theme</string>
     <string name="pref_key_ui_volumeButtonsScrolling_enabled" translatable="false">ui.volumeButtonsScrolling.enabled</string>
     <string name="pref_key_ui_tapToScroll_enabled" translatable="false">ui.tapToScroll.enabled</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="notification_unknownError">Unknown error</string>
     <string name="notification_expandedError">Error: %s</string>
     <string name="menu_lists_search">Search</string>
+    <string name="menu_lists_changeSortOrder">Change sort order</string>
     <string name="other_searchHint">Search by article title or text</string>
 
     <string name="pref_name_runConnectionWizard">Run connection wizard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,7 +168,6 @@
     <string name="pref_name_ui_article_fontSize">Article font size (%)</string>
     <string name="pref_name_ui_article_fontSerif">Serif typeface</string>
     <string name="pref_desc_ui_article_fontSerif">Serif typeface for article fonts</string>
-    <string name="pref_name_ui_lists_limit">Articles list limit</string>
     <string name="pref_categoryName_ui_screenScrolling">Screen scrolling</string>
     <string name="pref_name_ui_volumeButtonsScrolling_enabled">Scroll with volume buttons</string>
     <string name="pref_name_ui_tapToScroll_enabled">Tap-to-scroll</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,8 @@
     <string name="notification_incorrectConfiguration">Incorrect configuration</string>
     <string name="notification_unknownError">Unknown error</string>
     <string name="notification_expandedError">Error: %s</string>
+    <string name="menu_lists_search">Search</string>
+    <string name="other_searchHint">Search by article title or text</string>
 
     <string name="pref_name_runConnectionWizard">Run connection wizard</string>
     <string name="pref_desc_runConnectionWizard">The connection wizard will help you to set up basic connection settings</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -89,11 +89,6 @@
             android:title="@string/pref_name_ui_article_fontSerif"
             android:summary="@string/pref_desc_ui_article_fontSerif"
             android:defaultValue="false" />
-        <fr.gaulupeau.apps.Poche.ui.preferences.IntEditTextPreference
-            android:key="@string/pref_key_ui_lists_limit"
-            android:title="@string/pref_name_ui_lists_limit"
-            android:inputType="number"
-            android:defaultValue="100" />
       </PreferenceCategory>
         <PreferenceCategory android:title="@string/pref_categoryName_ui_screenScrolling">
             <CheckBoxPreference

--- a/app/src/main/res/xml/searchable.xml
+++ b/app/src/main/res/xml/searchable.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<searchable xmlns:android="http://schemas.android.com/apk/res/android"
+            android:label="@string/app_name"
+            android:hint="@string/other_searchHint" />


### PR DESCRIPTION
Adds "endless scrolling" instead of limited list. Memory may still be an issue.

Use `DiffUtil` to update lists partially.

I'm not completely sure about the implementation, so suggestions are welcome.

~~Also, I think I had an issue with the lists not being updated after actions like "open an article - add it to favorite - go back to lists". I couldn't reproduce it yet. I added logging of warning messages "fragment is null". I'm pretty sure it should either update list or log the warning. I have no idea why the fragments can be null after they were initialized (initially I thought, that it might be related to threading, but only the main thread is supposed to access fragments).~~ Probably fixed with 2630998.

Related issues:
* Basic search: partly #113.
* Sync queue before full update: #127.
* Sorting order: partly #17 and #42.

Testing needed.