### PR TITLE
Theme fixes

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/AddActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/AddActivity.java
@@ -13,7 +13,6 @@ public class AddActivity extends BaseActionBarActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Themes.applyTheme(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_add);
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
@@ -12,7 +12,6 @@ import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
 import android.util.Log;
@@ -45,7 +44,7 @@ import fr.gaulupeau.apps.Poche.ui.preferences.SettingsActivity;
 
 import static fr.gaulupeau.apps.Poche.data.ListTypes.*;
 
-public class ArticlesListActivity extends AppCompatActivity
+public class ArticlesListActivity extends BaseActionBarActivity
         implements ArticlesListFragment.OnFragmentInteractionListener,
         ViewPager.OnPageChangeListener {
 
@@ -81,8 +80,8 @@ public class ArticlesListActivity extends AppCompatActivity
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Themes.applyTheme(this);
         super.onCreate(savedInstanceState);
+        hideBackButtonFromActionBar();
         setContentView(R.layout.activity_articles_list);
 
         Log.v(TAG, "onCreate()");

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticlesListActivity.java
@@ -284,9 +284,19 @@ public class ArticlesListActivity extends BaseActionBarActivity
                 openRandomArticle();
                 return true;
             case R.id.menuAbout:
+                Libs.ActivityStyle style;
+                switch(Themes.getCurrentTheme()) {
+                    case DARK:
+                    case DARK_CONTRAST:
+                        style = Libs.ActivityStyle.DARK;
+                        break;
+
+                    default:
+                        style = Libs.ActivityStyle.LIGHT_DARK_TOOLBAR;
+                        break;
+                }
                 new LibsBuilder()
-                        //provide a style (optional) (LIGHT, DARK, LIGHT_DARK_TOOLBAR)
-                        .withActivityStyle(Libs.ActivityStyle.LIGHT_DARK_TOOLBAR)
+                        .withActivityStyle(style)
                         .withAboutIconShown(true)
                         .withAboutVersionShown(true)
                         .withAboutDescription(getResources().getString(R.string.aboutText))

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/BaseActionBarActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/BaseActionBarActivity.java
@@ -1,42 +1,44 @@
 package fr.gaulupeau.apps.Poche.ui;
 
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.view.MenuItem;
 
 public abstract class BaseActionBarActivity extends AppCompatActivity {
 
-    private static final String TAG = BaseActionBarActivity.class.getSimpleName();
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        Themes.applyTheme(this);
         super.onCreate(savedInstanceState);
+
         addBackButtonToActionBar();
     }
 
-    protected void addBackButtonToActionBar() {
-        try {
-            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        } catch (Exception e) {
-            Log.w(TAG, e);
-        }
+    @Override
+    protected void onStart() {
+        super.onStart();
+
+        Themes.checkTheme(this);
     }
 
-    protected void hideBackButtonToActionBar() {
-        try {
-            getSupportActionBar().setDisplayHomeAsUpEnabled(false);
-        } catch (Exception e) {
-            Log.w(TAG, e);
-        }
+    protected void addBackButtonToActionBar() {
+        ActionBar actionBar = getSupportActionBar();
+        if(actionBar != null) actionBar.setDisplayHomeAsUpEnabled(true);
+    }
+
+    protected void hideBackButtonFromActionBar() {
+        ActionBar actionBar = getSupportActionBar();
+        if(actionBar != null) actionBar.setDisplayHomeAsUpEnabled(false);
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home) {
-            this.finish();
+        if(item.getItemId() == android.R.id.home) {
+            finish();
             return true;
         }
         return super.onOptionsItemSelected(item);
     }
+
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -108,7 +108,6 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     private int fontSize;
 
     public void onCreate(Bundle savedInstanceState) {
-        Themes.applyTheme(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.article);
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
@@ -2,12 +2,17 @@ package fr.gaulupeau.apps.Poche.ui;
 
 import android.app.Activity;
 
+import java.util.Map;
+import java.util.WeakHashMap;
+
 import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.App;
 
 public class Themes {
 
     private static Theme theme;
+
+    private static Map<Activity, Theme> appliedThemes = new WeakHashMap<>();
 
     static {
         init();
@@ -23,10 +28,17 @@ public class Themes {
 
     public static void applyTheme(Activity activity) {
         activity.setTheme(theme.getResId());
+        appliedThemes.put(activity, theme);
     }
 
     public static void applyProxyTheme(Activity activity) {
         activity.setTheme(theme.getProxyResId());
+        appliedThemes.put(activity, theme);
+    }
+
+    public static void checkTheme(Activity activity) {
+        Theme appliedTheme = appliedThemes.get(activity);
+        if(appliedTheme != theme) activity.recreate();
     }
 
     public enum Theme {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
@@ -25,6 +25,7 @@ import fr.gaulupeau.apps.Poche.data.Settings;
 import fr.gaulupeau.apps.Poche.network.WallabagConnection;
 import fr.gaulupeau.apps.Poche.network.WallabagServiceEndpoint;
 import fr.gaulupeau.apps.Poche.network.tasks.TestFeedsTask;
+import fr.gaulupeau.apps.Poche.ui.Themes;
 
 // TODO: split classes?
 public class ConnectionWizardActivity extends AppCompatActivity {
@@ -71,6 +72,7 @@ public class ConnectionWizardActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        Themes.applyTheme(this);
         super.onCreate(savedInstanceState);
 
         if(savedInstanceState == null) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
@@ -7,7 +7,6 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -25,10 +24,10 @@ import fr.gaulupeau.apps.Poche.data.Settings;
 import fr.gaulupeau.apps.Poche.network.WallabagConnection;
 import fr.gaulupeau.apps.Poche.network.WallabagServiceEndpoint;
 import fr.gaulupeau.apps.Poche.network.tasks.TestFeedsTask;
-import fr.gaulupeau.apps.Poche.ui.Themes;
+import fr.gaulupeau.apps.Poche.ui.BaseActionBarActivity;
 
 // TODO: split classes?
-public class ConnectionWizardActivity extends AppCompatActivity {
+public class ConnectionWizardActivity extends BaseActionBarActivity {
 
     public static final String EXTRA_SKIP_WELCOME = "skip_welcome";
     public static final String EXTRA_SHOW_SUMMARY = "show_summary";
@@ -72,7 +71,6 @@ public class ConnectionWizardActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Themes.applyTheme(this);
         super.onCreate(savedInstanceState);
 
         if(savedInstanceState == null) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -9,7 +9,6 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -24,13 +23,13 @@ import fr.gaulupeau.apps.Poche.network.WallabagServiceEndpoint;
 import fr.gaulupeau.apps.Poche.network.tasks.TestFeedsTask;
 import fr.gaulupeau.apps.Poche.service.AlarmHelper;
 import fr.gaulupeau.apps.Poche.service.ServiceHelper;
+import fr.gaulupeau.apps.Poche.ui.BaseActionBarActivity;
 import fr.gaulupeau.apps.Poche.ui.Themes;
 
-public class SettingsActivity extends AppCompatActivity {
+public class SettingsActivity extends BaseActionBarActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Themes.applyTheme(this);
         super.onCreate(savedInstanceState);
 
         getFragmentManager().beginTransaction()
@@ -64,8 +63,6 @@ public class SettingsActivity extends AppCompatActivity {
         };
 
         private Settings settings;
-
-        private boolean newTheme;
 
         private boolean autoSyncChanged;
         private boolean oldAutoSyncEnabled;
@@ -180,8 +177,6 @@ public class SettingsActivity extends AppCompatActivity {
         private void resetChanges() {
             Log.d(TAG, "resetChanges() started");
 
-            newTheme = false;
-
             autoSyncChanged = false;
             oldAutoSyncEnabled = settings.isAutoSyncEnabled();
             oldAutoSyncInterval = settings.getAutoSyncInterval();
@@ -201,13 +196,6 @@ public class SettingsActivity extends AppCompatActivity {
 
         private void applyChanges() {
             Log.d(TAG, "applyChanges() started");
-
-            if(newTheme) {
-                newTheme = false;
-                Log.d(TAG, "applyChanges() newTheme is true");
-
-                Themes.init();
-            }
 
             if(autoSyncChanged) {
                 autoSyncChanged = false;
@@ -308,10 +296,12 @@ public class SettingsActivity extends AppCompatActivity {
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
             Log.d(TAG, "onSharedPreferenceChanged(" + key + ")");
 
+            boolean themeChanged = false;
+
             int keyResID = Settings.getPrefKeyIDByValue(key);
             switch(keyResID) {
                 case R.string.pref_key_ui_theme:
-                    newTheme = true;
+                    themeChanged = true;
                     break;
 
                 case R.string.pref_key_autoSync_enabled:
@@ -358,6 +348,15 @@ public class SettingsActivity extends AppCompatActivity {
 
             // not optimal :/
             updateSummary(keyResID);
+
+            if(themeChanged) {
+                Log.d(TAG, "onSharedPreferenceChanged() theme changed");
+
+                Themes.init();
+
+                Activity activity = getActivity();
+                if(activity != null) Themes.checkTheme(activity);
+            }
         }
 
         @Override

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -32,9 +32,11 @@ public class SettingsActivity extends BaseActionBarActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        getFragmentManager().beginTransaction()
-                .replace(android.R.id.content, new SettingsFragment())
-                .commit();
+        if(savedInstanceState == null) {
+            getFragmentManager().beginTransaction()
+                    .replace(android.R.id.content, new SettingsFragment())
+                    .commit();
+        }
     }
 
     public static class SettingsFragment extends PreferenceFragment

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -1,22 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="pref_key_main" translatable="false">main</string>
+
+    <string name="pref_key_connection" translatable="false">connection</string>
+    <string name="pref_key_connection_category" translatable="false">connection.category</string>
     <string name="pref_key_connection_url" translatable="false">connection.url</string>
     <string name="pref_key_connection_serverVersion" translatable="false">connection.serverVersion</string>
     <string name="pref_key_connection_username" translatable="false">connection.username</string>
     <string name="pref_key_connection_password" translatable="false">connection.password</string>
     <string name="pref_key_connection_feedsUserID" translatable="false">connection.feedsUserID</string>
     <string name="pref_key_connection_feedsToken" translatable="false">connection.feedsToken</string>
+    <string name="pref_key_connection_advanced" translatable="false">connection.advanced</string>
+    <string name="pref_key_connection_advanced_category" translatable="false">connection.advanced.category</string>
     <string name="pref_key_connection_advanced_acceptAllCertificates" translatable="false">connection.advanced.acceptAllCertificates</string>
     <string name="pref_key_connection_advanced_customSSLSettings" translatable="false">connection.advanced.customSSLSettings</string>
+    <string name="pref_key_connection_advanced_httpAuth_category" translatable="false">connection.advanced.httpAuth.category</string>
     <string name="pref_key_connection_advanced_httpAuthUsername" translatable="false">connection.advanced.httpAuthUsername</string>
     <string name="pref_key_connection_advanced_httpAuthPassword" translatable="false">connection.advanced.httpAuthPassword</string>
 
+    <string name="pref_key_ui" translatable="false">ui</string>
+    <string name="pref_key_ui_category" translatable="false">ui.category</string>
     <string name="pref_key_ui_article_fontSize" translatable="false">ui.article.fontSize</string>
     <string name="pref_key_ui_article_fontSerif" translatable="false">ui.article.fontSerif</string>
     <string name="pref_key_ui_lists_sortOrder" translatable="false">ui.lists.sortOrder</string>
     <string name="pref_key_ui_theme" translatable="false">ui.theme</string>
     <string name="pref_key_ui_volumeButtonsScrolling_enabled" translatable="false">ui.volumeButtonsScrolling.enabled</string>
     <string name="pref_key_ui_tapToScroll_enabled" translatable="false">ui.tapToScroll.enabled</string>
+    <string name="pref_key_ui_screenScrolling" translatable="false">ui.screenScrolling</string>
     <string name="pref_key_ui_screenScrolling_percent" translatable="false">ui.screenScrolling.percent</string>
     <string name="pref_key_ui_screenScrolling_smooth" translatable="false">ui.screenScrolling.smooth</string>
 
@@ -29,6 +39,8 @@
     <string name="pref_key_tts_languageVoice_prefix" translatable="false">tts.languageVoice.</string>
     <string name="pref_key_tts_autoplayNext" translatable="false">tts.autoplayNext</string>
 
+    <string name="pref_key_autoSync" translatable="false">autoSync</string>
+    <string name="pref_key_autoSync_category" translatable="false">autoSync.category</string>
     <string name="pref_key_autoSync_enabled" translatable="false">autoSync.enabled</string>
     <string name="pref_key_autoSync_interval" translatable="false">autoSync.interval</string>
     <string name="pref_key_autoSync_type" translatable="false">autoSync.type</string>
@@ -36,6 +48,8 @@
     <string name="pref_key_autoDlNew_enabled" translatable="false">autoDlNew.enabled</string>
     <string name="pref_key_imageCache_enabled" translatable="false">imageCache.enabled</string>
 
+    <string name="pref_key_misc" translatable="false">misc</string>
+    <string name="pref_key_misc_category" translatable="false">misc.category</string>
     <string name="pref_key_misc_handleHttpScheme" translatable="false">misc.handleHttpScheme</string>
     <string name="pref_key_misc_wipeDB" translatable="false">misc.wipeDB</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -3,7 +3,7 @@
     <Preference
         android:key="@string/pref_key_connection_wizard"
         android:title="@string/pref_name_runConnectionWizard"
-        android:summary="@string/pref_desc_runConnectionWizard" >
+        android:summary="@string/pref_desc_runConnectionWizard">
     </Preference>
     <PreferenceScreen android:title="@string/pref_categoryName_connection">
         <PreferenceCategory android:title="@string/pref_categoryName_connection">
@@ -11,16 +11,16 @@
                 android:key="@string/pref_key_connection_url"
                 android:title="@string/pref_name_connection_url"
                 android:summary="@string/pref_desc_connection_url"
-                android:defaultValue="http://" />
+                android:defaultValue="http://"/>
             <EditTextPreference
                 android:key="@string/pref_key_connection_username"
                 android:title="@string/pref_name_connection_username"
-                android:defaultValue="" />
+                android:defaultValue=""/>
             <EditTextPreference
                 android:key="@string/pref_key_connection_password"
                 android:title="@string/pref_name_connection_password"
                 android:inputType="textPassword"
-                android:defaultValue="" />
+                android:defaultValue=""/>
             <Preference
                 android:key="@string/pref_key_connection_autofill"
                 android:title="@string/pref_name_connection_autofill"
@@ -31,136 +31,137 @@
                 android:dialogTitle="@string/pref_name_connection_serverVersion"
                 android:entries="@array/pref_option_connection_serverVersion"
                 android:entryValues="@array/pref_option_connection_serverVersion_values"
-                android:defaultValue="-1" />
+                android:defaultValue="-1"/>
             <EditTextPreference
                 android:key="@string/pref_key_connection_feedsUserID"
                 android:title="@string/pref_name_connection_feedsUserID"
-                android:defaultValue="" />
+                android:defaultValue=""/>
             <EditTextPreference
                 android:key="@string/pref_key_connection_feedsToken"
                 android:title="@string/pref_name_connection_feedsToken"
-                android:defaultValue="" />
+                android:defaultValue=""/>
         </PreferenceCategory>
         <PreferenceScreen android:title="@string/pref_categoryName_connection_advanced">
-          <PreferenceCategory android:title="@string/pref_categoryName_connection_advanced">
-            <CheckBoxPreference
-                android:key="@string/pref_key_connection_advanced_acceptAllCertificates"
-                android:title="@string/pref_name_connection_advanced_acceptAllCertificates"
-                android:summary="@string/pref_desc_connection_advanced_acceptAllCertificates"
-                android:defaultValue="false" />
-            <CheckBoxPreference
-                android:key="@string/pref_key_connection_advanced_customSSLSettings"
-                android:title="@string/pref_name_connection_advanced_customSSLSettings"
-                android:summary="@string/pref_desc_connection_advanced_customSSLSettings"
-                android:defaultValue="false" />
-            <Preference
-                android:key="@string/pref_key_connection_advanced_clearCookies"
-                android:title="@string/pref_name_connection_advanced_clearCookies"
-                android:summary="@string/pref_desc_connection_advanced_clearCookies"/>
+            <PreferenceCategory android:title="@string/pref_categoryName_connection_advanced">
+                <CheckBoxPreference
+                    android:key="@string/pref_key_connection_advanced_acceptAllCertificates"
+                    android:title="@string/pref_name_connection_advanced_acceptAllCertificates"
+                    android:summary="@string/pref_desc_connection_advanced_acceptAllCertificates"
+                    android:defaultValue="false"/>
+                <CheckBoxPreference
+                    android:key="@string/pref_key_connection_advanced_customSSLSettings"
+                    android:title="@string/pref_name_connection_advanced_customSSLSettings"
+                    android:summary="@string/pref_desc_connection_advanced_customSSLSettings"
+                    android:defaultValue="false"/>
+                <Preference
+                    android:key="@string/pref_key_connection_advanced_clearCookies"
+                    android:title="@string/pref_name_connection_advanced_clearCookies"
+                    android:summary="@string/pref_desc_connection_advanced_clearCookies"/>
             </PreferenceCategory>
-            <PreferenceCategory android:title="@string/pref_categoryName_connection_advanced_httpAuth"
+            <PreferenceCategory
+                android:title="@string/pref_categoryName_connection_advanced_httpAuth"
                 android:summary="@string/pref_categoryDesc_connection_advanced_httpAuth">
                 <EditTextPreference
                     android:key="@string/pref_key_connection_advanced_httpAuthUsername"
                     android:title="@string/pref_name_connection_advanced_httpAuthUsername"
-                    android:defaultValue="" />
+                    android:defaultValue=""/>
                 <EditTextPreference
                     android:key="@string/pref_key_connection_advanced_httpAuthPassword"
                     android:title="@string/pref_name_connection_advanced_httpAuthPassword"
                     android:inputType="textPassword"
-                    android:defaultValue="" />
+                    android:defaultValue=""/>
             </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_categoryName_ui">
-      <PreferenceCategory android:title="@string/pref_categoryName_ui">
-        <ListPreference
-            android:key="@string/pref_key_ui_theme"
-            android:title="@string/pref_name_ui_theme"
-            android:dialogTitle="@string/pref_name_ui_theme"
-            android:defaultValue="LIGHT" />
-        <fr.gaulupeau.apps.Poche.ui.preferences.IntEditTextPreference
-            android:key="@string/pref_key_ui_article_fontSize"
-            android:title="@string/pref_name_ui_article_fontSize"
-            android:inputType="number"
-            android:defaultValue="100" />
-        <CheckBoxPreference
-            android:key="@string/pref_key_ui_article_fontSerif"
-            android:title="@string/pref_name_ui_article_fontSerif"
-            android:summary="@string/pref_desc_ui_article_fontSerif"
-            android:defaultValue="false" />
-      </PreferenceCategory>
+        <PreferenceCategory android:title="@string/pref_categoryName_ui">
+            <ListPreference
+                android:key="@string/pref_key_ui_theme"
+                android:title="@string/pref_name_ui_theme"
+                android:dialogTitle="@string/pref_name_ui_theme"
+                android:defaultValue="LIGHT"/>
+            <fr.gaulupeau.apps.Poche.ui.preferences.IntEditTextPreference
+                android:key="@string/pref_key_ui_article_fontSize"
+                android:title="@string/pref_name_ui_article_fontSize"
+                android:inputType="number"
+                android:defaultValue="100"/>
+            <CheckBoxPreference
+                android:key="@string/pref_key_ui_article_fontSerif"
+                android:title="@string/pref_name_ui_article_fontSerif"
+                android:summary="@string/pref_desc_ui_article_fontSerif"
+                android:defaultValue="false"/>
+        </PreferenceCategory>
         <PreferenceCategory android:title="@string/pref_categoryName_ui_screenScrolling">
             <CheckBoxPreference
                 android:key="@string/pref_key_ui_volumeButtonsScrolling_enabled"
                 android:title="@string/pref_name_ui_volumeButtonsScrolling_enabled"
-                android:defaultValue="false" />
+                android:defaultValue="false"/>
             <CheckBoxPreference
                 android:key="@string/pref_key_ui_tapToScroll_enabled"
                 android:title="@string/pref_name_ui_tapToScroll_enabled"
                 android:summary="@string/pref_desc_ui_tapToScroll_enabled"
-                android:defaultValue="false" />
+                android:defaultValue="false"/>
             <fr.gaulupeau.apps.Poche.ui.preferences.FloatEditTextPreference
                 android:key="@string/pref_key_ui_screenScrolling_percent"
                 android:title="@string/pref_name_ui_screenScrolling_percent"
                 android:inputType="numberDecimal"
-                android:defaultValue="95" />
+                android:defaultValue="95"/>
             <CheckBoxPreference
                 android:key="@string/pref_key_ui_screenScrolling_smooth"
                 android:title="@string/pref_name_ui_screenScrolling_smooth"
-                android:defaultValue="true" />
+                android:defaultValue="true"/>
         </PreferenceCategory>
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_categoryName_autoSync">
-      <PreferenceCategory android:title="@string/pref_categoryName_autoSync">
-        <CheckBoxPreference
-            android:key="@string/pref_key_autoSync_enabled"
-            android:title="@string/pref_name_autoSync_enabled"
-            android:summary="@string/pref_desc_autoSync_enabled"
-            android:defaultValue="false" />
-        <fr.gaulupeau.apps.Poche.ui.preferences.LongListPreference
-            android:dependency="@string/pref_key_autoSync_enabled"
-            android:key="@string/pref_key_autoSync_interval"
-            android:title="@string/pref_name_autoSync_interval"
-            android:dialogTitle="@string/pref_name_autoSync_interval"
-            android:defaultValue="86400000" />
-        <fr.gaulupeau.apps.Poche.ui.preferences.IntListPreference
-            android:dependency="@string/pref_key_autoSync_enabled"
-            android:key="@string/pref_key_autoSync_type"
-            android:title="@string/pref_name_autoSync_type"
-            android:dialogTitle="@string/pref_name_autoSync_type"
-            android:entries="@array/pref_option_autoSync_type"
-            android:entryValues="@array/pref_option_autoSync_type_values"
-            android:defaultValue="0" />
-        <CheckBoxPreference
-            android:key="@string/pref_key_autoSyncQueue_enabled"
-            android:title="@string/pref_name_autoSyncQueue_enabled"
-            android:summary="@string/pref_desc_autoSyncQueue_enabled"
-            android:defaultValue="false" />
-        <CheckBoxPreference
-            android:key="@string/pref_key_autoDlNew_enabled"
-            android:title="@string/pref_name_autoDlNew_enabled"
-            android:summary="@string/pref_desc_autoDlNew_enabled"
-            android:defaultValue="false" />
-        <CheckBoxPreference
-            android:key="@string/pref_key_imageCache_enabled"
-            android:title="@string/pref_name_imageCache_enabled"
-            android:summary="@string/pref_desc_imageCache_enabled"
-            android:defaultValue="false" />
+        <PreferenceCategory android:title="@string/pref_categoryName_autoSync">
+            <CheckBoxPreference
+                android:key="@string/pref_key_autoSync_enabled"
+                android:title="@string/pref_name_autoSync_enabled"
+                android:summary="@string/pref_desc_autoSync_enabled"
+                android:defaultValue="false"/>
+            <fr.gaulupeau.apps.Poche.ui.preferences.LongListPreference
+                android:dependency="@string/pref_key_autoSync_enabled"
+                android:key="@string/pref_key_autoSync_interval"
+                android:title="@string/pref_name_autoSync_interval"
+                android:dialogTitle="@string/pref_name_autoSync_interval"
+                android:defaultValue="86400000"/>
+            <fr.gaulupeau.apps.Poche.ui.preferences.IntListPreference
+                android:dependency="@string/pref_key_autoSync_enabled"
+                android:key="@string/pref_key_autoSync_type"
+                android:title="@string/pref_name_autoSync_type"
+                android:dialogTitle="@string/pref_name_autoSync_type"
+                android:entries="@array/pref_option_autoSync_type"
+                android:entryValues="@array/pref_option_autoSync_type_values"
+                android:defaultValue="0"/>
+            <CheckBoxPreference
+                android:key="@string/pref_key_autoSyncQueue_enabled"
+                android:title="@string/pref_name_autoSyncQueue_enabled"
+                android:summary="@string/pref_desc_autoSyncQueue_enabled"
+                android:defaultValue="false"/>
+            <CheckBoxPreference
+                android:key="@string/pref_key_autoDlNew_enabled"
+                android:title="@string/pref_name_autoDlNew_enabled"
+                android:summary="@string/pref_desc_autoDlNew_enabled"
+                android:defaultValue="false"/>
+            <CheckBoxPreference
+                android:key="@string/pref_key_imageCache_enabled"
+                android:title="@string/pref_name_imageCache_enabled"
+                android:summary="@string/pref_desc_imageCache_enabled"
+                android:defaultValue="false"/>
         </PreferenceCategory>
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_categoryName_miscellaneous">
-      <PreferenceCategory android:title="@string/pref_categoryName_miscellaneous">
-        <CheckBoxPreference
-            android:key="@string/pref_key_misc_handleHttpScheme"
-            android:title="@string/pref_name_misc_handleHttpScheme"
-            android:summary="@string/pref_desc_misc_handleHttpScheme"
-            android:defaultValue="false"
-            android:persistent="false" />
-        <Preference
-            android:key="@string/pref_key_misc_wipeDB"
-            android:title="@string/pref_name_misc_wipeDB"
-            android:summary="@string/pref_desc_misc_wipeDB" />
+        <PreferenceCategory android:title="@string/pref_categoryName_miscellaneous">
+            <CheckBoxPreference
+                android:key="@string/pref_key_misc_handleHttpScheme"
+                android:title="@string/pref_name_misc_handleHttpScheme"
+                android:summary="@string/pref_desc_misc_handleHttpScheme"
+                android:defaultValue="false"
+                android:persistent="false"/>
+            <Preference
+                android:key="@string/pref_key_misc_wipeDB"
+                android:title="@string/pref_name_misc_wipeDB"
+                android:summary="@string/pref_desc_misc_wipeDB"/>
         </PreferenceCategory>
     </PreferenceScreen>
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:key="@string/pref_key_main"
+    android:persistent="false">
     <Preference
         android:key="@string/pref_key_connection_wizard"
         android:title="@string/pref_name_runConnectionWizard"
-        android:summary="@string/pref_desc_runConnectionWizard">
+        android:summary="@string/pref_desc_runConnectionWizard"
+        android:persistent="false">
     </Preference>
-    <PreferenceScreen android:title="@string/pref_categoryName_connection">
-        <PreferenceCategory android:title="@string/pref_categoryName_connection">
+    <PreferenceScreen
+        android:key="@string/pref_key_connection"
+        android:title="@string/pref_categoryName_connection"
+        android:persistent="false">
+        <PreferenceCategory
+            android:key="@string/pref_key_connection_category"
+            android:title="@string/pref_categoryName_connection"
+            android:persistent="false">
             <EditTextPreference
                 android:key="@string/pref_key_connection_url"
                 android:title="@string/pref_name_connection_url"
@@ -24,7 +34,8 @@
             <Preference
                 android:key="@string/pref_key_connection_autofill"
                 android:title="@string/pref_name_connection_autofill"
-                android:summary="@string/pref_desc_connection_autofill"/>
+                android:summary="@string/pref_desc_connection_autofill"
+                android:persistent="false"/>
             <fr.gaulupeau.apps.Poche.ui.preferences.IntListPreference
                 android:key="@string/pref_key_connection_serverVersion"
                 android:title="@string/pref_name_connection_serverVersion"
@@ -41,8 +52,14 @@
                 android:title="@string/pref_name_connection_feedsToken"
                 android:defaultValue=""/>
         </PreferenceCategory>
-        <PreferenceScreen android:title="@string/pref_categoryName_connection_advanced">
-            <PreferenceCategory android:title="@string/pref_categoryName_connection_advanced">
+        <PreferenceScreen
+            android:key="@string/pref_key_connection_advanced"
+            android:title="@string/pref_categoryName_connection_advanced"
+            android:persistent="false">
+            <PreferenceCategory
+                android:key="@string/pref_key_connection_advanced_category"
+                android:title="@string/pref_categoryName_connection_advanced"
+                android:persistent="false">
                 <CheckBoxPreference
                     android:key="@string/pref_key_connection_advanced_acceptAllCertificates"
                     android:title="@string/pref_name_connection_advanced_acceptAllCertificates"
@@ -56,11 +73,14 @@
                 <Preference
                     android:key="@string/pref_key_connection_advanced_clearCookies"
                     android:title="@string/pref_name_connection_advanced_clearCookies"
-                    android:summary="@string/pref_desc_connection_advanced_clearCookies"/>
+                    android:summary="@string/pref_desc_connection_advanced_clearCookies"
+                    android:persistent="false"/>
             </PreferenceCategory>
             <PreferenceCategory
+                android:key="@string/pref_key_connection_advanced_httpAuth_category"
                 android:title="@string/pref_categoryName_connection_advanced_httpAuth"
-                android:summary="@string/pref_categoryDesc_connection_advanced_httpAuth">
+                android:summary="@string/pref_categoryDesc_connection_advanced_httpAuth"
+                android:persistent="false">
                 <EditTextPreference
                     android:key="@string/pref_key_connection_advanced_httpAuthUsername"
                     android:title="@string/pref_name_connection_advanced_httpAuthUsername"
@@ -73,8 +93,14 @@
             </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceScreen>
-    <PreferenceScreen android:title="@string/pref_categoryName_ui">
-        <PreferenceCategory android:title="@string/pref_categoryName_ui">
+    <PreferenceScreen
+        android:key="@string/pref_key_ui"
+        android:title="@string/pref_categoryName_ui"
+        android:persistent="false">
+        <PreferenceCategory
+            android:key="@string/pref_key_ui_category"
+            android:title="@string/pref_categoryName_ui"
+            android:persistent="false">
             <ListPreference
                 android:key="@string/pref_key_ui_theme"
                 android:title="@string/pref_name_ui_theme"
@@ -91,7 +117,10 @@
                 android:summary="@string/pref_desc_ui_article_fontSerif"
                 android:defaultValue="false"/>
         </PreferenceCategory>
-        <PreferenceCategory android:title="@string/pref_categoryName_ui_screenScrolling">
+        <PreferenceCategory
+            android:key="@string/pref_key_ui_screenScrolling"
+            android:title="@string/pref_categoryName_ui_screenScrolling"
+            android:persistent="false">
             <CheckBoxPreference
                 android:key="@string/pref_key_ui_volumeButtonsScrolling_enabled"
                 android:title="@string/pref_name_ui_volumeButtonsScrolling_enabled"
@@ -112,8 +141,14 @@
                 android:defaultValue="true"/>
         </PreferenceCategory>
     </PreferenceScreen>
-    <PreferenceScreen android:title="@string/pref_categoryName_autoSync">
-        <PreferenceCategory android:title="@string/pref_categoryName_autoSync">
+    <PreferenceScreen
+        android:key="@string/pref_key_autoSync"
+        android:title="@string/pref_categoryName_autoSync"
+        android:persistent="false">
+        <PreferenceCategory
+            android:key="@string/pref_key_autoSync_category"
+            android:title="@string/pref_categoryName_autoSync"
+            android:persistent="false">
             <CheckBoxPreference
                 android:key="@string/pref_key_autoSync_enabled"
                 android:title="@string/pref_name_autoSync_enabled"
@@ -150,8 +185,14 @@
                 android:defaultValue="false"/>
         </PreferenceCategory>
     </PreferenceScreen>
-    <PreferenceScreen android:title="@string/pref_categoryName_miscellaneous">
-        <PreferenceCategory android:title="@string/pref_categoryName_miscellaneous">
+    <PreferenceScreen
+        android:key="@string/pref_key_misc"
+        android:title="@string/pref_categoryName_miscellaneous"
+        android:persistent="false">
+        <PreferenceCategory
+            android:key="@string/pref_key_misc_category"
+            android:title="@string/pref_categoryName_miscellaneous"
+            android:persistent="false">
             <CheckBoxPreference
                 android:key="@string/pref_key_misc_handleHttpScheme"
                 android:title="@string/pref_name_misc_handleHttpScheme"
@@ -161,7 +202,8 @@
             <Preference
                 android:key="@string/pref_key_misc_wipeDB"
                 android:title="@string/pref_name_misc_wipeDB"
-                android:summary="@string/pref_desc_misc_wipeDB"/>
+                android:summary="@string/pref_desc_misc_wipeDB"
+                android:persistent="false"/>
         </PreferenceCategory>
     </PreferenceScreen>
 </PreferenceScreen>


### PR DESCRIPTION
Apply themes without app restart (the activities restart themselves if needed). #338, #405.
Also fix theme not being applied to the Connection Wizard and the about screen (only dark/light for the about screen).