### PR TITLE
ImageCache: fix NPE

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/ImageCacheUtils.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/ImageCacheUtils.java
@@ -291,6 +291,11 @@ public class ImageCacheUtils {
             } else {
                 // TODO: better SD Card detection
                 for(File extStorageDir: extStorage) {
+                    if(extStorageDir == null) {
+                        Log.w(TAG, "getExternalStoragePath: extStorageDir is null");
+                        continue;
+                    }
+
                     Log.d(TAG, "getExternalStoragePath: extStorageDir.getPath()="
                             + extStorageDir.getPath());
                     returnPath = extStorageDir.getPath();


### PR DESCRIPTION
Fix crash from Google Play Console:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.io.File.getPath()' on a null object reference
	at fr.gaulupeau.apps.Poche.network.ImageCacheUtils.getExternalStoragePath(ImageCacheUtils.java:280)
	at fr.gaulupeau.apps.Poche.network.ImageCacheUtils.isExternalStorageWritable(ImageCacheUtils.java:300)
	at fr.gaulupeau.apps.Poche.service.SecondaryService.fetchImages(SecondaryService.java:222)
	at fr.gaulupeau.apps.Poche.service.SecondaryService.onHandleIntent(SecondaryService.java:68)
	at android.app.IntentService$ServiceHandler.handleMessage(IntentService.java:67)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:154)
	at android.os.HandlerThread.run(HandlerThread.java:61)
```