### PR TITLE
Update permissions and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ On Android versions prior to Android 6.0, wallabag requires the following permis
 - Full Network Access.
 - View Network Connections.
 - Run at startup.
+- Read and write access to external storage.
 
-The "Run at startup" permission is only used if Auto-Sync is enabled and is not utilised when Auto-Sync is disabled. The other two permissions are made use of for downloading content for viewing offline.
+The "Run at startup" permission is only used if Auto-Sync is enabled and is not utilised otherwise. The network access permissions are made use of for downloading content. The external storage permission is used to cache article images for viewing offline.
 
 ## Contributing
 wallabag app is a free and open source project developed by volunteers. Any contributions are welcome. Here are a few ways you can help:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18"/>
 
     <application
         android:name="fr.gaulupeau.apps.Poche.App"


### PR DESCRIPTION
The `WRITE_EXTERNAL_STORAGE` permission [is not required](https://developer.android.com/guide/topics/data/data-storage.html#AccessingExtFiles) since Android 4.4 to access application-private directories on external storage.