### PR TITLE
Fix storage access for image caching

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="22"/>
 
     <application
         android:name="fr.gaulupeau.apps.Poche.App"


### PR DESCRIPTION
It seems I've broken storage access in #433 for Android API levels ∈ [19; 22]. 
#433 was correct according to docs, but there seems to be [a bug](https://code.google.com/p/android/issues/detail?id=81357).

As a result, the app on these devices may silently ignore "cache images" option.