### PR TITLE
Avoid IllegalStateException in ConnectionWizardActivity

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
@@ -233,7 +233,7 @@ public class ConnectionWizardActivity extends BaseActionBarActivity {
                     .replace(android.R.id.content, goToFragment)
                     .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
             if(!noBackStack && !PAGE_NONE.equals(currentPage)) ft.addToBackStack(null);
-            ft.commit();
+            ft.commitAllowingStateLoss();
         }
     }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConnectionWizardActivity.java
@@ -160,7 +160,7 @@ public class ConnectionWizardActivity extends BaseActionBarActivity {
 
         String[] values = data.split("@");
 
-        if (values.length < 1 || values.length > 2) {
+        if(values.length != 2) {
             // error illegal number of URI elements detected
             throw new IllegalArgumentException("Illegal number of login URL elements detected: " + values.length);
         }


### PR DESCRIPTION
From Google Play Console:
```
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
	at android.support.v4.app.FragmentManagerImpl.checkStateLoss(FragmentManager.java:1842)
	at android.support.v4.app.FragmentManagerImpl.enqueueAction(FragmentManager.java:1860)
	at android.support.v4.app.BackStackRecord.commitInternal(BackStackRecord.java:649)
	at android.support.v4.app.BackStackRecord.commit(BackStackRecord.java:609)
	at fr.gaulupeau.apps.Poche.ui.preferences.ConnectionWizardActivity.next(ConnectionWizardActivity.java:236)
	at fr.gaulupeau.apps.Poche.ui.preferences.ConnectionWizardActivity.next(ConnectionWizardActivity.java:187)
	at fr.gaulupeau.apps.Poche.ui.preferences.ConnectionWizardActivity.next(ConnectionWizardActivity.java:183)
	at fr.gaulupeau.apps.Poche.ui.preferences.ConnectionWizardActivity$WizardPageFragment.goForward(ConnectionWizardActivity.java:311)
	at fr.gaulupeau.apps.Poche.ui.preferences.ConnectionWizardActivity$GenericConfigFragment.onConfigurationTestSuccess(ConnectionWizardActivity.java:463)
	at fr.gaulupeau.apps.Poche.ui.preferences.ConfigurationTestHelper.onTestApiAccessTaskResult(ConfigurationTestHelper.java:343)
	at fr.gaulupeau.apps.Poche.network.tasks.TestApiAccessTask.onPostExecute(TestApiAccessTask.java:146)
	at fr.gaulupeau.apps.Poche.network.tasks.TestApiAccessTask.onPostExecute(TestApiAccessTask.java:16)
	at android.os.AsyncTask.finish(AsyncTask.java:651)
	at android.os.AsyncTask.-wrap1(AsyncTask.java)
	at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:668)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:148)
	at android.app.ActivityThread.main(ActivityThread.java:5443)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:728)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:618)
```

Generally, such exceptions should be handled differently, but in the case of Connection Wizard we can tolerate minor state loss.