### PR TITLE
Enable user-added CAs on API 24+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:icon="@drawable/icon"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/LightTheme">
+        android:theme="@style/LightTheme"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name="fr.gaulupeau.apps.Poche.ui.MainActivity"
             android:theme="@style/LightTheme.NoActionBar">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Should fix #479.
https://developer.android.com/training/articles/security-config.html#base-config