### PR TITLE
Improve processing of connection test results

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConfigurationTestHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/ConfigurationTestHelper.java
@@ -145,24 +145,23 @@ public class ConfigurationTestHelper
 
                 for(int i = results.size() - 1; i >= 0; i--) {
                     TestConnectionTask.TestResult result = results.get(i);
-                    String url = result.url;
-                    if(TestConnectionTask.areUrlsEqual(url, this.url)) {
-                        if(result.result == WallabagWebService.ConnectionTestResult.OK) {
-                            isOriginalOk = true;
 
-                            if(bestUrl == null) {
-                                bestUrl = result.url;
+                    boolean originalUrl = TestConnectionTask.areUrlsEqual(result.url, url);
+
+                    if(result.result == WallabagWebService.ConnectionTestResult.OK) {
+                        if(originalUrl) isOriginalOk = true;
+
+                        if(bestUrl == null) {
+                            bestUrl = result.url;
+
+                            if(originalUrl) {
                                 isOriginalBest = true;
                                 break;
                             }
-                        } else {
-                            error = result.result;
-                            errorMessage = result.errorMessage;
                         }
-                    } else if(result.result == WallabagWebService.ConnectionTestResult.OK) {
-                        if(bestUrl == null) {
-                            bestUrl = result.url;
-                        }
+                    } else if(originalUrl || error == null) {
+                        error = result.result;
+                        errorMessage = result.errorMessage;
                     }
                 }
 


### PR DESCRIPTION
There is a bug where the app shows unknown error instead of a real one.

Test case:
Use Connection Wizard to set up the app. Enter wallabag URL without specifying protocol, enter incorrect credentials.

Expected result:
Incorrect credentials error.

Actual result:
Unknown error.

This PR should fix it.