### PR TITLE
fix tables, images and quotes in dark themes

### DIFF
--- a/app/src/main/assets/dark.css
+++ b/app/src/main/assets/dark.css
@@ -51,6 +51,24 @@ p, li {
   color: #FFF;
 }
 
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+table, th, td {
+  color: #FFF;
+  border:1px solid #999;
+  padding: 0.25em;
+  text-align: left;
+}
+
+/* fix images with transparent background */
+img {
+  background: #FFF;
+  max-width: 100%;
+}
+
 .high-contrast p,
 .high-contrast li {
   color: #FFF;
@@ -202,11 +220,17 @@ header.mbm {
   font-style: normal;
 }
 
-blockquote {
-  border:1px solid #999;
-  background: #000;
-  padding: 1em;
+blockquote, pre {
+  border: 1px solid #999;
+  background: #222;
+  padding: 0.25em;
   margin: 0;
+}
+
+#article pre {
+  font-family: monospace;
+  white-space: pre;
+  text-justify: none;
 }
 
 #article h2, #article h3, #article h4 {


### PR DESCRIPTION
Improves #562, fixes #559 Tested with dark and dark high contrast themes.

Tables: (Before, After)
http://www.techstage.de/test/Coda-Wireless-guenstiger-Bluetooth-Kopfhoerer-im-Test-3675740.html
![screenshot_2017-06-18-11-23-20](https://user-images.githubusercontent.com/10577978/27259907-325d45de-541e-11e7-9572-457ab1568471.png)
![screenshot_2017-06-18-12-14-55](https://user-images.githubusercontent.com/10577978/27260032-b77a4764-5421-11e7-9c1e-ce5137f46174.png)

https://github.com/open-guides/og-aws
![screenshot_2017-06-18-11-25-06](https://user-images.githubusercontent.com/10577978/27259937-126fab58-541f-11e7-9fe5-9569139312a5.png)
![screenshot_2017-06-18-11-57-19](https://user-images.githubusercontent.com/10577978/27259938-14b535b8-541f-11e7-8810-a988af69fd1d.png)

Images with transparent backgound: (Before, After)
https://www.linux.com/blog/learn/chapter/Intro-to-Kubernetes/2017/5/set-cicd-pipeline-kubernetes-part-1-overview
![screenshot_2017-06-18-11-26-17](https://user-images.githubusercontent.com/10577978/27259917-b1b24f82-541e-11e7-93e5-1e0804ffd5e8.png)
![screenshot_2017-06-18-11-34-09](https://user-images.githubusercontent.com/10577978/27259918-b5e5572a-541e-11e7-8b05-37a5dd34af59.png)

Pre, quote blocks: (Before, After)
https://www.linux.com/blog/learn/chapter/Intro-to-Kubernetes/2017/5/set-cicd-pipeline-kubernetes-part-1-overview
![screenshot_2017-06-18-12-00-23](https://user-images.githubusercontent.com/10577978/27259921-c721b128-541e-11e7-86ac-664c08969e0b.png)
![screenshot_2017-06-18-11-56-36](https://user-images.githubusercontent.com/10577978/27259922-ca8b0aa8-541e-11e7-8923-3004bf1dcf51.png)
