### PR TITLE
onCollapse of search menu, invalidate options menu

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
@@ -314,6 +314,7 @@ public class MainActivity extends AppCompatActivity
             @Override
             public boolean onMenuItemActionCollapse(MenuItem item) {
                 Log.v(TAG, "searchMenuItem collapsed");
+                supportInvalidateOptionsMenu();
                 searchMenuItemExpanded = false;
                 return true;
             }


### PR DESCRIPTION
This fixes #457
For further documentation about supportInvalidateOptionsMenu(), see https://developer.android.com/reference/android/support/v4/app/FragmentActivity.html#supportInvalidateOptionsMenu()