### PR TITLE
Add Android O support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ android:
     - platform-tools
 
     # The BuildTools version used by your project
-    - build-tools-25.0.3
+    - build-tools-26.0.0
 
     # The SDK version used to compile your project
-    - android-25
+    - android-26
 
     # Additional components
     # - extra-google-google_play_services

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.greenrobot.greendao'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.0'
 
     defaultConfig {
         applicationId "fr.gaulupeau.apps.InThePoche"
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 104
         versionName "2.0.0"
 
@@ -50,12 +50,12 @@ greendao {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
+    compile 'com.android.support:appcompat-v7:26.0.0-beta2'
+    compile 'com.android.support:support-v4:26.0.0-beta2'
+    compile 'com.android.support:recyclerview-v7:26.0.0-beta2'
+    compile 'com.android.support:design:26.0.0-beta2'
     // workaround for https://code.google.com/p/android/issues/detail?id=231324
-    compile 'com.android.support:cardview-v7:25.3.1'
+    compile 'com.android.support:cardview-v7:26.0.0-beta2'
     compile 'org.greenrobot:eventbus:3.0.0'
     compile 'org.greenrobot:greendao:3.2.2'
     annotationProcessor 'org.greenrobot:eventbus-annotation-processor:3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,11 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
+        maven {
+            url "https://jitpack.io"
+        }
+        maven {
+            url 'https://maven.google.com'
+        }
     }
 }


### PR DESCRIPTION
This adds the new [android maven repo](https://developer.android.com/preview/migration.html#uya) and sets the required version of Android from API 11 (Android 3.0) to API 14 (Android 4.0), because of a Google library. According to the Play Store stats, only 0.1% of users should be affected.

This shouldn't be released until Android O is out (in a few weeks I guess).