### PR TITLE
Change article links style

### DIFF
--- a/app/src/main/assets/dark.css
+++ b/app/src/main/assets/dark.css
@@ -76,8 +76,8 @@ img {
 }
 
 a {
-  color: #FFF;
-  font-weight: bold;
+  color: #039be5;
+  text-decoration: none;
 }
 
 a:hover, a:focus {

--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -67,8 +67,8 @@ table, th, td {
 }
 
 a {
-  color: #000;
-  font-weight: bold;
+  color: #039be5;
+  text-decoration: none;
 }
 
 a:hover, a:focus {

--- a/app/src/main/assets/solarized.css
+++ b/app/src/main/assets/solarized.css
@@ -85,7 +85,7 @@ table, th, td {
 
 a {
   color: #b58900; /* $yellow; */
-  font-weight: bold;
+  text-decoration: none;
 }
 
 a:hover, a:focus {


### PR DESCRIPTION
Try to fix  #173.
I removed the underline and bold style in all themes. I used the "blue" from Wallabag web in dark and light themes. Solarized theme color remains the same.
![screenshot_2017-07-01-08-27-50](https://user-images.githubusercontent.com/10577978/27759779-6121b790-5e39-11e7-95f6-b46e99a622a0.png)
![screenshot_2017-07-01-08-31-55](https://user-images.githubusercontent.com/10577978/27759783-62db7d96-5e39-11e7-840f-41e7ecc58438.png)
![screenshot_2017-07-01-08-32-51](https://user-images.githubusercontent.com/10577978/27759785-64a905c6-5e39-11e7-9c7f-f565a493e242.png)
![screenshot_2017-07-01-08-33-58](https://user-images.githubusercontent.com/10577978/27759786-66ae74e6-5e39-11e7-9f88-60316d561b43.png)
![screenshot_2017-07-01-08-34-37](https://user-images.githubusercontent.com/10577978/27759787-6aa9714a-5e39-11e7-8047-f6d59cb8e1ae.png)
![screenshot_2017-07-01-08-39-28](https://user-images.githubusercontent.com/10577978/27759788-6c71cdb0-5e39-11e7-880b-408ffe75d0a7.png)
