### PR TITLE
Improve CSS styles for quotes

### DIFF
--- a/app/src/main/assets/dark.css
+++ b/app/src/main/assets/dark.css
@@ -220,7 +220,7 @@ header.mbm {
   font-style: normal;
 }
 
-blockquote, pre {
+#article blockquote, #article pre {
   border: 1px solid #999;
   background: #222;
   padding: 0.25em;
@@ -231,6 +231,10 @@ blockquote, pre {
   font-family: monospace;
   white-space: pre;
   text-justify: none;
+}
+
+#article blockquote *, #article pre * {
+  background: inherit;
 }
 
 #article h2, #article h3, #article h4 {

--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -210,7 +210,7 @@ header.mbm {
   font-style: normal;
 }
 
-blockquote, pre {
+#article blockquote, #article pre {
   border: 1px solid #999;
   background: #DDD;
   padding: 0.25em;
@@ -221,6 +221,10 @@ blockquote, pre {
   font-family: monospace;
   white-space: pre;
   text-justify: none;
+}
+
+#article blockquote *, #article pre * {
+  background: inherit;
 }
 
 #article h2, #article h3, #article h4 {

--- a/app/src/main/assets/solarized.css
+++ b/app/src/main/assets/solarized.css
@@ -228,7 +228,7 @@ header.mbm {
   font-style: normal;
 }
 
-blockquote, pre {
+#article blockquote, #article pre {
   border:1px solid #999;
   background: #eee8d5; /* $base2*/
   padding: 0.25em;
@@ -239,6 +239,10 @@ blockquote, pre {
   font-family: monospace;
   white-space: pre;
   text-justify: none;
+}
+
+#article blockquote *, #article pre * {
+  background: inherit;
 }
 
 #article h2, #article h3, #article h4 {


### PR DESCRIPTION
This is happening only in some articles, but won't break anything. Look at the quote background.
Before:
![screenshot_2017-07-07-20-52-13](https://user-images.githubusercontent.com/10577978/27972401-8c60e5d0-6356-11e7-9229-f9ef7c739b4d.png)
With this PR:
![screenshot_2017-07-07-20-53-38](https://user-images.githubusercontent.com/10577978/27972409-923a78d6-6356-11e7-9db1-2593c645df36.png)
