### PR TITLE
Use PAGE_UP and PAGE_DOWN keycodes for scrolling

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -322,6 +322,16 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
+        switch(event.getKeyCode()) {
+            case KeyEvent.KEYCODE_PAGE_UP:
+                scroll(true, screenScrollingPercent, smoothScrolling);
+                return true;
+
+            case KeyEvent.KEYCODE_PAGE_DOWN:
+                scroll(false, screenScrollingPercent, smoothScrolling);
+                return true;
+        }
+
         if(volumeButtonsScrolling) {
             switch(event.getKeyCode()) {
                 case KeyEvent.KEYCODE_VOLUME_UP:


### PR DESCRIPTION
Improvement for #168.

Uses parameters under "screen scrolling" in settings.

To emulate key presses (for testing):
`PAGE_UP`: `adb shell input keyevent 92`.
`PAGE_DOWN`: `adb shell input keyevent 93`.