### PR TITLE
add toggling touch via physical button

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -9,6 +9,7 @@ import android.os.Build;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.KeyEvent;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -452,6 +453,30 @@ public class Settings {
 
     public void setScreenScrollingSmooth(boolean value) {
         setBoolean(R.string.pref_key_ui_screenScrolling_smooth, value);
+    }
+
+    public boolean isDisableTouchEnabled() {
+        return getBoolean(R.string.pref_key_ui_disableTouch_enabled, false);
+    }
+
+    public void setDisableTouchEnabled(boolean value) {
+        setBoolean(R.string.pref_key_ui_disableTouch_enabled, value);
+    }
+
+    public boolean isDisableTouchLastState() {
+        return getBoolean(R.string.pref_key_ui_disableTouch_lastState, false);
+    }
+
+    public void setDisableTouchLastState(boolean value) {
+        setBoolean(R.string.pref_key_ui_disableTouch_lastState, value);
+    }
+
+    public int getDisableTouchKeyCode() {
+        return getInt(R.string.pref_key_ui_disableTouch_keyCode, KeyEvent.KEYCODE_CAMERA);
+    }
+
+    public void setDisableTouchKeyCode(int keyCode) {
+        setInt(R.string.pref_key_ui_disableTouch_keyCode, keyCode);
     }
 
     public boolean isTtsVisible() {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -337,39 +337,42 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        switch(event.getKeyCode()) {
-            case KeyEvent.KEYCODE_PAGE_UP:
-                scroll(true, screenScrollingPercent, smoothScrolling);
-                return true;
 
-            case KeyEvent.KEYCODE_PAGE_DOWN:
-                scroll(false, screenScrollingPercent, smoothScrolling);
-                return true;
+        // only do this once per key press (otherwise the action is done twice)
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            switch (event.getKeyCode()) {
+                case KeyEvent.KEYCODE_PAGE_UP:
+                    scroll(true, screenScrollingPercent, smoothScrolling);
+                    return true;
 
-            case KeyEvent.KEYCODE_CAMERA:
-                if(event.getAction() == KeyEvent.ACTION_DOWN) {
-                    // only do this once per key press (otherwise it's toggled immediately off again with the following KeyEvent.ACTION_UP
+                case KeyEvent.KEYCODE_PAGE_DOWN:
+                    scroll(false, screenScrollingPercent, smoothScrolling);
+                    return true;
+
+                case KeyEvent.KEYCODE_CAMERA:
+
                     disableTouch = !disableTouch;
 
-                    if(disableTouch) {
+                    if (disableTouch) {
                         Toast.makeText(this, "Touch screen disabled", Toast.LENGTH_SHORT).show();
                     } else {
                         Toast.makeText(this, "Touch screen enabled", Toast.LENGTH_SHORT).show();
                     }
                     Log.d(TAG, "toggling touch screen, now disableTouch is " + disableTouch);
+                    return true;
+            }
+
+
+            if (volumeButtonsScrolling) {
+                switch (event.getKeyCode()) {
+                    case KeyEvent.KEYCODE_VOLUME_UP:
+                        scroll(true, screenScrollingPercent, smoothScrolling);
+                        return true;
+
+                    case KeyEvent.KEYCODE_VOLUME_DOWN:
+                        scroll(false, screenScrollingPercent, smoothScrolling);
+                        return true;
                 }
-                return true;
-        }
-
-        if(volumeButtonsScrolling) {
-            switch(event.getKeyCode()) {
-                case KeyEvent.KEYCODE_VOLUME_UP:
-                    scroll(true, screenScrollingPercent, smoothScrolling);
-                    return true;
-
-                case KeyEvent.KEYCODE_VOLUME_DOWN:
-                    scroll(false, screenScrollingPercent, smoothScrolling);
-                    return true;
             }
         }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -350,9 +350,7 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                     return true;
 
                 case KeyEvent.KEYCODE_CAMERA:
-
                     disableTouch = !disableTouch;
-
                     if (disableTouch) {
                         Toast.makeText(this, "Touch screen disabled", Toast.LENGTH_SHORT).show();
                     } else {
@@ -360,21 +358,25 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                     }
                     Log.d(TAG, "toggling touch screen, now disableTouch is " + disableTouch);
                     return true;
-            }
 
-
-            if (volumeButtonsScrolling) {
-                switch (event.getKeyCode()) {
-                    case KeyEvent.KEYCODE_VOLUME_UP:
+								case KeyEvent.KEYCODE_VOLUME_UP:
+										if (volumeButtonsScrolling) {
                         scroll(true, screenScrollingPercent, smoothScrolling);
                         return true;
+										} else {
+												return super.dispatchKeyEvent(event);
+										}
 
-                    case KeyEvent.KEYCODE_VOLUME_DOWN:
+                case KeyEvent.KEYCODE_VOLUME_DOWN:
+										if (volumeButtonsScrolling) {
                         scroll(false, screenScrollingPercent, smoothScrolling);
                         return true;
-                }
-            }
-        }
+										} else {
+												return super.dispatchKeyEvent(event);
+										}
+
+            } // end switch
+        } // end if
 
         return super.dispatchKeyEvent(event);
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -109,7 +109,9 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     private int fontSize;
     private boolean volumeButtonsScrolling;
     private boolean tapToScroll;
+    private boolean disableTouchOptionEnabled;
     private boolean disableTouch;
+    private int disableTouchKeyCode;
     private float screenScrollingPercent;
     private boolean smoothScrolling;
 
@@ -135,19 +137,6 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     private boolean isResumed;
     private boolean onPageFinishedCallPostponedUntilResume;
     private boolean loadingFinished;
-
-    @Override
-    public boolean dispatchTouchEvent(MotionEvent ev){
-        // from https://stackoverflow.com/a/28429348
-        if (disableTouch) {
-            return true;
-        } else {
-            // call root view and don't claim to have consumed the touchEvent
-            // https://stackoverflow.com/a/22490810
-            super.dispatchTouchEvent(ev);
-            return false;
-        }
-    }
 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -177,7 +166,9 @@ public class ReadArticleActivity extends BaseActionBarActivity {
         fontSize = settings.getArticleFontSize();
         volumeButtonsScrolling = settings.isVolumeButtonsScrollingEnabled();
         tapToScroll = settings.isTapToScrollEnabled();
-        disableTouch = false; // will be toggled by pressing the key defined in dispatchKeyEvent()
+        disableTouchOptionEnabled = settings.isDisableTouchEnabled();
+        disableTouch = settings.isDisableTouchLastState();
+        disableTouchKeyCode = settings.getDisableTouchKeyCode();
         screenScrollingPercent = settings.getScreenScrollingPercent();
         smoothScrolling = settings.isScreenScrollingSmooth();
 
@@ -210,6 +201,10 @@ public class ReadArticleActivity extends BaseActionBarActivity {
             if(ttsFragment == null) {
                 toggleTTS(false);
             }
+        }
+
+        if(disableTouch) {
+            showDisableTouchToast();
         }
 
         EventBus.getDefault().register(this);
@@ -337,48 +332,40 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-
-        // only do this once per key press (otherwise the action is done twice)
         if (event.getAction() == KeyEvent.ACTION_DOWN) {
-            switch (event.getKeyCode()) {
+            int code = event.getKeyCode();
+
+            if(code == disableTouchKeyCode && (disableTouch || disableTouchOptionEnabled)) {
+                disableTouch = !disableTouch;
+                settings.setDisableTouchLastState(disableTouch);
+
+                Log.d(TAG, "toggling touch screen, now disableTouch is " + disableTouch);
+                showDisableTouchToast();
+                return true;
+            }
+
+            switch (code) {
                 case KeyEvent.KEYCODE_PAGE_UP:
-                    scroll(true, screenScrollingPercent, smoothScrolling);
-                    return true;
-
                 case KeyEvent.KEYCODE_PAGE_DOWN:
-                    scroll(false, screenScrollingPercent, smoothScrolling);
-                    return true;
-
-                case KeyEvent.KEYCODE_CAMERA:
-                    disableTouch = !disableTouch;
-                    if (disableTouch) {
-                        Toast.makeText(this, "Touch screen disabled", Toast.LENGTH_SHORT).show();
-                    } else {
-                        Toast.makeText(this, "Touch screen enabled", Toast.LENGTH_SHORT).show();
-                    }
-                    Log.d(TAG, "toggling touch screen, now disableTouch is " + disableTouch);
+                    scroll(code == KeyEvent.KEYCODE_PAGE_UP, screenScrollingPercent, smoothScrolling);
                     return true;
 
                 case KeyEvent.KEYCODE_VOLUME_UP:
-                    if (volumeButtonsScrolling) {
-                        scroll(true, screenScrollingPercent, smoothScrolling);
-                        return true;
-                    } else {
-                        return super.dispatchKeyEvent(event);
-                    }
-
                 case KeyEvent.KEYCODE_VOLUME_DOWN:
                     if (volumeButtonsScrolling) {
-                        scroll(false, screenScrollingPercent, smoothScrolling);
+                        scroll(code == KeyEvent.KEYCODE_VOLUME_UP, screenScrollingPercent, smoothScrolling);
                         return true;
-                    } else {
-                        return super.dispatchKeyEvent(event);
                     }
-
-            } // end switch
-        } // end if
+                    break;
+            }
+        }
 
         return super.dispatchKeyEvent(event);
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent ev) {
+        return disableTouch || super.dispatchTouchEvent(ev);
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -463,6 +450,13 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
 //            restorePositionAfterUpdate();
         }
+    }
+
+    private void showDisableTouchToast() {
+        Toast.makeText(this, disableTouch
+                        ? R.string.message_disableTouch_inputDisabled
+                        : R.string.message_disableTouch_inputEnabled,
+                Toast.LENGTH_SHORT).show();
     }
 
     @SuppressLint("SetJavaScriptEnabled")

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -359,21 +359,21 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                     Log.d(TAG, "toggling touch screen, now disableTouch is " + disableTouch);
                     return true;
 
-								case KeyEvent.KEYCODE_VOLUME_UP:
-										if (volumeButtonsScrolling) {
+                case KeyEvent.KEYCODE_VOLUME_UP:
+                    if (volumeButtonsScrolling) {
                         scroll(true, screenScrollingPercent, smoothScrolling);
                         return true;
-										} else {
-												return super.dispatchKeyEvent(event);
-										}
+                    } else {
+                        return super.dispatchKeyEvent(event);
+                    }
 
                 case KeyEvent.KEYCODE_VOLUME_DOWN:
-										if (volumeButtonsScrolling) {
+                    if (volumeButtonsScrolling) {
                         scroll(false, screenScrollingPercent, smoothScrolling);
                         return true;
-										} else {
-												return super.dispatchKeyEvent(event);
-										}
+                    } else {
+                        return super.dispatchKeyEvent(event);
+                    }
 
             } // end switch
         } // end if

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -145,7 +145,6 @@ public class ReadArticleActivity extends BaseActionBarActivity {
             // call root view and don't claim to have consumed the touchEvent
             // https://stackoverflow.com/a/22490810
             super.dispatchTouchEvent(ev);
-            //findViewById(R.id.viewMain).dispatchTouchEvent(ev);
             return false;
         }
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -109,6 +109,7 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     private int fontSize;
     private boolean volumeButtonsScrolling;
     private boolean tapToScroll;
+    private boolean disableTouch;
     private float screenScrollingPercent;
     private boolean smoothScrolling;
 
@@ -134,6 +135,20 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     private boolean isResumed;
     private boolean onPageFinishedCallPostponedUntilResume;
     private boolean loadingFinished;
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent ev){
+        // from https://stackoverflow.com/a/28429348
+        if (disableTouch) {
+            return true;
+        } else {
+            // call root view and don't claim to have consumed the touchEvent
+            // https://stackoverflow.com/a/22490810
+            super.dispatchTouchEvent(ev);
+            //findViewById(R.id.viewMain).dispatchTouchEvent(ev);
+            return false;
+        }
+    }
 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -163,6 +178,7 @@ public class ReadArticleActivity extends BaseActionBarActivity {
         fontSize = settings.getArticleFontSize();
         volumeButtonsScrolling = settings.isVolumeButtonsScrollingEnabled();
         tapToScroll = settings.isTapToScrollEnabled();
+        disableTouch = false; // will be toggled by pressing the key defined in dispatchKeyEvent()
         screenScrollingPercent = settings.getScreenScrollingPercent();
         smoothScrolling = settings.isScreenScrollingSmooth();
 
@@ -329,6 +345,20 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
             case KeyEvent.KEYCODE_PAGE_DOWN:
                 scroll(false, screenScrollingPercent, smoothScrolling);
+                return true;
+
+            case KeyEvent.KEYCODE_CAMERA:
+                if(event.getAction() == KeyEvent.ACTION_DOWN) {
+                    // only do this once per key press (otherwise it's toggled immediately off again with the following KeyEvent.ACTION_UP
+                    disableTouch = !disableTouch;
+
+                    if(disableTouch) {
+                        Toast.makeText(this, "Touch screen disabled", Toast.LENGTH_SHORT).show();
+                    } else {
+                        Toast.makeText(this, "Touch screen enabled", Toast.LENGTH_SHORT).show();
+                    }
+                    Log.d(TAG, "toggling touch screen, now disableTouch is " + disableTouch);
+                }
                 return true;
         }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -1,5 +1,6 @@
 package fr.gaulupeau.apps.Poche.ui.preferences;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlarmManager;
 import android.content.DialogInterface;
@@ -12,6 +13,9 @@ import android.support.v7.app.AlertDialog;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.KeyEvent;
+import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import java.util.ArrayList;
@@ -112,6 +116,7 @@ public class SettingsActivity extends BaseActionBarActivity {
             setOnClickListener(R.string.pref_key_connection_wizard);
             setOnClickListener(R.string.pref_key_connection_autofill);
             setOnClickListener(R.string.pref_key_sync_syncTypes_description);
+            setOnClickListener(R.string.pref_key_ui_disableTouch_keyCode);
             setOnClickListener(R.string.pref_key_misc_wipeDB);
 
             ListPreference themeListPreference = (ListPreference)findPreference(
@@ -456,6 +461,10 @@ public class SettingsActivity extends BaseActionBarActivity {
                     }
                     return true;
                 }
+                case R.string.pref_key_ui_disableTouch_keyCode: {
+                    showDisableTouchSetKeyCodeDialog();
+                    return true;
+                }
                 case R.string.pref_key_misc_wipeDB: {
                     Activity activity = getActivity();
                     if(activity != null) {
@@ -476,6 +485,52 @@ public class SettingsActivity extends BaseActionBarActivity {
             }
 
             return false;
+        }
+
+        private void showDisableTouchSetKeyCodeDialog() {
+            Activity activity = getActivity();
+            if(activity != null) {
+                AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+                builder.setTitle(R.string.d_disableTouch_changeKey_title);
+
+                @SuppressLint("InflateParams")
+                final View view = activity.getLayoutInflater().inflate(R.layout.dialog_set_key, null);
+                final TextView keyCodeTextView = (TextView)view.findViewById(R.id.tv_keyCode);
+
+                setIntToTextView(keyCodeTextView, settings.getDisableTouchKeyCode());
+
+                builder.setView(view);
+
+                DialogInterface.OnKeyListener keyListener = new DialogInterface.OnKeyListener() {
+                    @Override
+                    public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event) {
+                        if (event.getAction() != KeyEvent.ACTION_DOWN) return false;
+
+                        setIntToTextView(keyCodeTextView, keyCode);
+
+                        return false;
+                    }
+                };
+
+                builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        try {
+                            settings.setDisableTouchKeyCode(Integer.parseInt(
+                                    keyCodeTextView.getText().toString()));
+                        } catch(NumberFormatException ignored) {}
+                    }
+                });
+                builder.setNegativeButton(android.R.string.cancel, null);
+                builder.setOnKeyListener(keyListener);
+
+                builder.show();
+            }
+        }
+
+        @SuppressLint("SetTextI18n")
+        private void setIntToTextView(TextView textView, int value) {
+            textView.setText(Integer.toString(value));
         }
 
         @Override

--- a/app/src/main/res/layout/dialog_set_key.xml
+++ b/app/src/main/res/layout/dialog_set_key.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:padding="16dp"
+              android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="10sp"
+        android:layout_gravity="center"
+        android:gravity="center_horizontal"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:text="@string/d_disableTouch_currentCode" />
+
+    <TextView
+        android:id="@+id/tv_keyCode"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:text="" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -32,6 +32,10 @@
     <string name="pref_key_ui_screenScrolling" translatable="false">ui.screenScrolling</string>
     <string name="pref_key_ui_screenScrolling_percent" translatable="false">ui.screenScrolling.percent</string>
     <string name="pref_key_ui_screenScrolling_smooth" translatable="false">ui.screenScrolling.smooth</string>
+    <string name="pref_key_ui_misc_category" translatable="false">ui.misc.category</string>
+    <string name="pref_key_ui_disableTouch_enabled" translatable="false">ui.disableTouch.enabled</string>
+    <string name="pref_key_ui_disableTouch_lastState" translatable="false">ui.disableTouch.lastState</string>
+    <string name="pref_key_ui_disableTouch_keyCode" translatable="false">ui.disableTouch.keyCode</string>
 
     <string name="pref_key_tts_visible" translatable="false">tts.visible</string>
     <string name="pref_key_tts_optionsVisible" translatable="false">tts.optionsVisible</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -154,6 +154,11 @@
 
     <string name="message_couldNotOpenUrl">Couldn\'t open this URL</string>
 
+    <string name="message_disableTouch_inputDisabled">Touch input disabled</string>
+    <string name="message_disableTouch_inputEnabled">Touch input enabled</string>
+    <string name="d_disableTouch_changeKey_title">Disable touch input button</string>
+    <string name="d_disableTouch_currentCode">Currently selected key code (press a button to change it):</string>
+
     <string name="pref_name_runConnectionWizard">Run connection wizard</string>
     <string name="pref_desc_runConnectionWizard">The connection wizard will help you to set up basic connection settings</string>
 
@@ -196,6 +201,11 @@
     <string name="pref_desc_ui_tapToScroll_enabled">Scroll screen by tapping on left and right screen sides</string>
     <string name="pref_name_ui_screenScrolling_percent">Percent of screen height to scroll</string>
     <string name="pref_name_ui_screenScrolling_smooth">Use smooth scrolling</string>
+    <string name="pref_categoryName_ui_misc">Miscellanea</string>
+    <string name="pref_name_ui_disableTouch_enabled">Disable touch input</string>
+    <string name="pref_desc_ui_disableTouch_enabled">Press the configured button (camera button by default) to block/unblock touch input on the reading screen (system controls are not affected)</string>
+    <string name="pref_name_ui_disableTouch_keyCode">Disable touch input button</string>
+    <string name="pref_desc_ui_disableTouch_keyCode">Press here to configure the button used to disable/enable touch input</string>
 
     <string name="pref_categoryName_sync">Synchronization</string>
     <string name="pref_name_sync_syncTypes">Synchronization types</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -136,6 +136,21 @@
                 android:title="@string/pref_name_ui_screenScrolling_smooth"
                 android:defaultValue="true"/>
         </PreferenceCategory>
+        <PreferenceCategory
+            android:key="@string/pref_key_ui_misc_category"
+            android:title="@string/pref_categoryName_ui_misc"
+            android:persistent="false">
+            <CheckBoxPreference
+                android:key="@string/pref_key_ui_disableTouch_enabled"
+                android:title="@string/pref_name_ui_disableTouch_enabled"
+                android:summary="@string/pref_desc_ui_disableTouch_enabled"
+                android:defaultValue="false"/>
+            <Preference
+                android:key="@string/pref_key_ui_disableTouch_keyCode"
+                android:title="@string/pref_name_ui_disableTouch_keyCode"
+                android:summary="@string/pref_desc_ui_disableTouch_keyCode"
+                android:persistent="false"/>
+        </PreferenceCategory>
     </PreferenceScreen>
     <PreferenceScreen
         android:key="@string/pref_key_sync"


### PR DESCRIPTION
Tested sucessfully on my e-ink android device (inkbook prime).

For now, `KeyEvent.KEYCODE_CAMERA` is hardcoded, as (a) this is the key used on my deice (inkbook prime) for this feature and (b) I wasn't sure how you set and retrieve app-wide options.

Also, the toast messages should be translatable, I guess, but again, I didn't know how to do this.

Feel free to change accordingly!