### PR TITLE
bump dependencies & version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ android:
     - platform-tools
 
     # The BuildTools version used by your project
-    - build-tools-25.0.3
+    - build-tools-26.0.2
 
     # The SDK version used to compile your project
-    - android-25
+    - android-26
 
     # Additional components
     # - extra-google-google_play_services

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,15 +2,15 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.greenrobot.greendao'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "fr.gaulupeau.apps.InThePoche"
-        minSdkVersion 11
-        targetSdkVersion 25
-        versionCode 105
-        versionName "2.0.1"
+        minSdkVersion 14
+        targetSdkVersion 26
+        versionCode 106
+        versionName "2.0.2"
 
         javaCompileOptions {
             annotationProcessorOptions {
@@ -50,12 +50,12 @@ greendao {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:support-v4:26.1.0'
+    compile 'com.android.support:recyclerview-v7:26.1.0'
+    compile 'com.android.support:design:26.1.0'
     // workaround for https://code.google.com/p/android/issues/detail?id=231324
-    compile 'com.android.support:cardview-v7:25.3.1'
+    compile 'com.android.support:cardview-v7:26.1.0'
     compile 'org.greenrobot:eventbus:3.0.0'
     compile 'org.greenrobot:greendao:3.2.2'
     annotationProcessor 'org.greenrobot:eventbus-annotation-processor:3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -14,5 +14,6 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://jitpack.io" }
+        maven { url 'https://maven.google.com' }
     }
 }


### PR DESCRIPTION
Now requires Android API v14 (Android 4.0) instead of v11 (Android 3.0), which seems reasonable nowdays.