### PR TITLE
fix lint DefaultLocale: Implied default locale in case conversion

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ManageArticleTagsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ManageArticleTagsActivity.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.data.DbConnection;
@@ -376,11 +377,11 @@ public class ManageArticleTagsActivity extends BaseActionBarActivity {
     private static Tag findTagByLabel(String label, List<Tag> list) {
         if(TextUtils.isEmpty(label)) return null;
 
-        label = label.toLowerCase();
+        label = label.toLowerCase(Locale.getDefault());
 
         for(Tag tag: list) {
             String tagLabel = tag.getLabel();
-            if(tagLabel != null && label.equals(tagLabel.toLowerCase())) return tag;
+            if(tagLabel != null && label.equals(tagLabel.toLowerCase(Locale.getDefault()))) return tag;
         }
 
         return null;
@@ -391,12 +392,12 @@ public class ManageArticleTagsActivity extends BaseActionBarActivity {
             return new ArrayList<>(src);
         }
 
-        label = label.toLowerCase();
+        label = label.toLowerCase(Locale.getDefault());
 
         List<Tag> result = new ArrayList<>();
         for(Tag tag: src) {
             String tagLabel = tag.getLabel();
-            if(tagLabel != null && tagLabel.toLowerCase().contains(label)) {
+            if(tagLabel != null && tagLabel.toLowerCase(Locale.getDefault()).contains(label)) {
                 if(excludeList != null && excludeList.contains(tag)) continue;
 
                 result.add(tag);


### PR DESCRIPTION
fixes lint messages in src/main/java/fr/gaulupeau/apps/Poche/ui/ManageArticleTagsActivity.java: Implicitly using the default locale is a common source of bugs