### PR TITLE
fix lint Formatting argument types inconsistent

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -97,7 +97,7 @@
     <string name="pref_name_connection_advanced_httpAuthPassword">HTTP-Authentifizierungspasswort</string>
 
     <string name="pref_name_ui_theme">Thema</string>
-    <string name="pref_name_ui_article_fontSize">Schriftgröße für Artikel (in %)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">Schriftgröße für Artikel (in %)</string>
     <string name="pref_name_ui_article_fontSerif">Serifenschrift</string>
     <string name="pref_desc_ui_article_fontSerif">Serifenschrift für Artikel</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -182,7 +182,7 @@
 
     <string name="pref_categoryName_ui">Interfaz</string>
     <string name="pref_name_ui_theme">Tema de la aplicación</string>
-    <string name="pref_name_ui_article_fontSize">Tamaño de letra del artículo (%)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">Tamaño de letra del artículo (%)</string>
     <string name="pref_name_ui_article_fontSerif">Tipografía Serif</string>
     <string name="pref_desc_ui_article_fontSerif">Usar tipografía Serif para el contenido del artículo</string>
     <string name="pref_name_ui_article_textAlignment_justify">Alineación del texto: justificado</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -173,7 +173,7 @@
 
     <string name="pref_categoryName_ui">Interfazea</string>
     <string name="pref_name_ui_theme">Aplikazioaren gaia</string>
-    <string name="pref_name_ui_article_fontSize">Artikuluaren letra-tamaina (%)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">Artikuluaren letra-tamaina (%)</string>
     <string name="pref_name_ui_article_fontSerif">Serif tipografia</string>
     <string name="pref_desc_ui_article_fontSerif">Serif tipografia artikuluen letra-tiporako</string>
     <string name="pref_name_ui_article_textAlignment_justify">Testu-lerrokatzea: justifikatua</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -102,7 +102,7 @@
     <string name="pref_name_connection_advanced_httpAuthPassword">Mot de passe Authentification HTTP</string>
 
     <string name="pref_name_ui_theme">Thème de l\'application</string>
-    <string name="pref_name_ui_article_fontSize">Taille de la police (%)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">Taille de la police (%)</string>
     <string name="pref_desc_ui_article_fontSerif">Police avec empattement (serif)</string>
     <string name="pref_name_ui_article_textAlignment_justify">Alignement du texte : justifié</string>
     <string name="pref_desc_ui_article_textAlignment_justify">Aligne le texte pour que chaque ligne ait la même longueur (comme dans les journaux ou les magazines)</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -135,7 +135,7 @@
 
     <string name="pref_categoryName_ui">Felület</string>
     <string name="pref_name_ui_theme">Alkalmazás kinézete</string>
-    <string name="pref_name_ui_article_fontSize">A Cikk betűmérete (%-ban)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">A Cikk betűmérete (%-ban)</string>
     <string name="pref_name_ui_article_fontSerif">Serif betűtípus</string>
     <string name="pref_desc_ui_article_fontSerif">A cikk szövege Serif betűtípusú legyen</string>
     <string name="pref_categoryName_ui_screenScrolling">Képernyő görgetés</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -169,7 +169,7 @@
 
     <string name="pref_categoryName_ui">UI</string>
     <string name="pref_name_ui_theme">Tema Applicazione</string>
-    <string name="pref_name_ui_article_fontSize">Dimensione font articolo (%)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">Dimensione font articolo (%)</string>
     <string name="pref_name_ui_article_fontSerif">Carattere Serif</string>
     <string name="pref_desc_ui_article_fontSerif">Carattere Serif per i font dell\'articolo</string>
     <string name="pref_name_ui_readingSpeed">Velocità di lettura</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -132,7 +132,7 @@
 
     <string name="pref_categoryName_ui">UI</string>
     <string name="pref_name_ui_theme">アプリケーション テーマ</string>
-    <string name="pref_name_ui_article_fontSize">記事のフォントサイズ (%)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">記事のフォントサイズ (%)</string>
     <string name="pref_name_ui_article_fontSerif">書体</string>
     <string name="pref_desc_ui_article_fontSerif">記事フォントの書体</string>
     <string name="pref_categoryName_ui_screenScrolling">画面のスクロール</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -169,7 +169,7 @@
 
     <string name="pref_categoryName_ui">Interfejs użytkownika</string>
     <string name="pref_name_ui_theme">Motyw aplikacji</string>
-    <string name="pref_name_ui_article_fontSize">Rozmiar czcionki artykułu (%)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">Rozmiar czcionki artykułu (%)</string>
     <string name="pref_name_ui_article_fontSerif">Krój czcionki szeryfowy</string>
     <string name="pref_desc_ui_article_fontSerif">Krój szeryfowy dla czcionek artykuły</string>
     <string name="pref_name_ui_readingSpeed">Prędkość czytania</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -88,7 +88,7 @@
     <string name="pref_name_connection_advanced_httpAuthPassword">Пароль для HTTP-аутентификации</string>
 
     <string name="pref_name_ui_theme">Тема приложения</string>
-    <string name="pref_name_ui_article_fontSize">Размер шрифта статей (%)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">Размер шрифта статей (%)</string>
     <string name="pref_name_ui_article_fontSerif">Шрифт с засечками</string>
     <string name="pref_desc_ui_article_fontSerif">Шрифт с засечками для статей</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -174,7 +174,7 @@
 
     <string name="pref_categoryName_ui">Arayüz</string>
     <string name="pref_name_ui_theme">Tema</string>
-    <string name="pref_name_ui_article_fontSize">Makale yazı tipi boyutu (%)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">Makale yazı tipi boyutu (%)</string>
     <string name="pref_name_ui_article_fontSerif">Serif yazı tipi</string>
     <string name="pref_desc_ui_article_fontSerif">Makalelerde Serif yazı tipi</string>
     <string name="pref_name_ui_article_textAlignment_justify">Metin hizalama: her iki tarafa da</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,7 +188,7 @@
 
     <string name="pref_categoryName_ui">UI</string>
     <string name="pref_name_ui_theme">App theme</string>
-    <string name="pref_name_ui_article_fontSize">Article text size (%)</string>
+    <string name="pref_name_ui_article_fontSize" formatted="false">Article text size (%)</string>
     <string name="pref_name_ui_article_fontSerif">Serif typeface</string>
     <string name="pref_desc_ui_article_fontSerif">Serif font for articles</string>
     <string name="pref_name_ui_article_textAlignment_justify">Text alignment: Justify</string>


### PR DESCRIPTION
fixes lint messages in strings.xml. Lint message was Inconsistent number
of arguments in formatting string pref_name_ui_article_fontSize; found
both 0 and 1.
So this commit adds formatted="false" to the strings where we do not
want formatting but the percentage sign.