### PR TITLE
fix lint Keyboard inaccessible widget

### DIFF
--- a/app/src/main/res/layout/fragment_tts.xml
+++ b/app/src/main/res/layout/fragment_tts.xml
@@ -196,6 +196,7 @@
                 android:src="@drawable/ic_redo_24dp"
                 android:layout_gravity="center_vertical|right"
                 android:clickable="true"
+                android:focusable="true"
                 android:visibility="visible"
                 android:paddingLeft="10sp"
                 android:paddingTop="10sp"


### PR DESCRIPTION
fixes lint message in src/main/res/layout/fragment_tts.xml:198: 'clickable' attribute found, please also add 'focusable'