### PR TITLE
update aboutlibraries to latest stable 5.9.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp-urlconnection:3.8.1'
     compile 'com.facebook.stetho:stetho:1.5.0'
     compile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
-    compile 'com.mikepenz:aboutlibraries:5.7.3'
+    compile 'com.mikepenz:aboutlibraries:5.9.6'
     compile 'com.github.di72nn.wallabag-api-wrapper:api-wrapper:3c987b1'
     compile 'org.slf4j:slf4j-android:1.7.25'
 }


### PR DESCRIPTION
we have migrated to android o in #586 and thus we can finally update the dependency