### PR TITLE
fullscreen article view (clean branch, supersedes #642)

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -364,6 +364,14 @@ public class Settings {
         setBoolean(R.string.pref_key_ui_article_textAlignment_justify, value);
     }
 
+    public boolean isFullscreenArticleView() {
+        return getBoolean(R.string.pref_key_ui_article_fullscreen, true);
+    }
+
+    public void setFullScreenArticleView(boolean value) {
+        setBoolean(R.string.pref_key_ui_article_fullscreen, value);
+    }
+
     public int getReadingSpeed() {
         return getInt(R.string.pref_key_ui_readingSpeed, 200);
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -365,7 +365,7 @@ public class Settings {
     }
 
     public boolean isFullscreenArticleView() {
-        return getBoolean(R.string.pref_key_ui_article_fullscreen, true);
+        return getBoolean(R.string.pref_key_ui_article_fullscreen, false);
     }
 
     public void setFullScreenArticleView(boolean value) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -148,6 +148,8 @@ public class ReadArticleActivity extends BaseActionBarActivity {
             requestWindowFeature(Window.FEATURE_NO_TITLE);
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                     WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            // TODO: hide wallabag's BaseActionBarActivity also, but restore it once out of article view
+            // TODO: fix initial setting of setting (checkbox is false, fullscreen is nevertheless on)
         }
 
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -21,6 +21,8 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.Window;
+import android.view.WindowManager;
 import android.webkit.ConsoleMessage;
 import android.webkit.HttpAuthHandler;
 import android.webkit.WebChromeClient;
@@ -139,6 +141,15 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     private boolean loadingFinished;
 
     public void onCreate(Bundle savedInstanceState) {
+
+        settings = App.getInstance().getSettings();
+
+        if(settings.isFullscreenArticleView()) {
+            requestWindowFeature(Window.FEATURE_NO_TITLE);
+            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        }
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.article);
 
@@ -151,8 +162,6 @@ public class ReadArticleActivity extends BaseActionBarActivity {
         if(intent.hasExtra(EXTRA_LIST_ARCHIVED)) {
             contextArchived = intent.getBooleanExtra(EXTRA_LIST_ARCHIVED, false);
         }
-
-        settings = App.getInstance().getSettings();
 
         DaoSession session = DbConnection.getSession();
         articleDao = session.getArticleDao();

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.text.TextUtils;
 import android.util.Log;
@@ -146,10 +147,12 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
         if(settings.isFullscreenArticleView()) {
             requestWindowFeature(Window.FEATURE_NO_TITLE);
-            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            // TODO: hide wallabag's BaseActionBarActivity also, but restore it once out of article view
-            // TODO: fix initial setting of setting (checkbox is false, fullscreen is nevertheless on)
+            getWindow().setFlags(
+                    WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                    WindowManager.LayoutParams.FLAG_FULLSCREEN
+                    );
+            ActionBar actionBar = super.getSupportActionBar();
+            if(actionBar != null) actionBar.hide();
         }
 
         super.onCreate(savedInstanceState);
@@ -343,7 +346,7 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+        if (event.getAction() == KeyEvent.ACTION_UP) {
             int code = event.getKeyCode();
 
             if(code == disableTouchKeyCode && (disableTouch || disableTouchOptionEnabled)) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -346,9 +346,15 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        if (event.getAction() == KeyEvent.ACTION_UP) {
-            int code = event.getKeyCode();
+        int code = event.getKeyCode();
+        boolean triggerAction;
+        if (code == KeyEvent.KEYCODE_PAGE_UP || code == KeyEvent.KEYCODE_PAGE_DOWN) {
+            triggerAction = (event.getAction() == KeyEvent.ACTION_UP);
+        } else {
+            triggerAction = (event.getAction() == KeyEvent.ACTION_DOWN);
+        }
 
+        if (triggerAction) {
             if(code == disableTouchKeyCode && (disableTouch || disableTouchOptionEnabled)) {
                 disableTouch = !disableTouch;
                 settings.setDisableTouchLastState(disableTouch);

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -23,7 +23,6 @@
     <string name="pref_key_ui_article_fontSize" translatable="false">ui.article.fontSize</string>
     <string name="pref_key_ui_article_fontSerif" translatable="false">ui.article.fontSerif</string>
     <string name="pref_key_ui_article_textAlignment_justify" translatable="false">ui.article.textAlignment.justify</string>
-    <string name="pref_key_ui_article_fullscreen" translatable="false">ui.article.fullscreen</string>
     <string name="pref_key_ui_readingSpeed" translatable="false">ui.readingSpeed</string>
     <string name="pref_key_ui_lists_sortOrder" translatable="false">ui.lists.sortOrder</string>
     <string name="pref_key_ui_tagList_sortOrder" translatable="false">ui.tagList.sortOrder</string>
@@ -34,6 +33,7 @@
     <string name="pref_key_ui_screenScrolling_percent" translatable="false">ui.screenScrolling.percent</string>
     <string name="pref_key_ui_screenScrolling_smooth" translatable="false">ui.screenScrolling.smooth</string>
     <string name="pref_key_ui_misc_category" translatable="false">ui.misc.category</string>
+    <string name="pref_key_ui_article_fullscreen" translatable="false">ui.article.fullscreen</string>
     <string name="pref_key_ui_disableTouch_enabled" translatable="false">ui.disableTouch.enabled</string>
     <string name="pref_key_ui_disableTouch_lastState" translatable="false">ui.disableTouch.lastState</string>
     <string name="pref_key_ui_disableTouch_keyCode" translatable="false">ui.disableTouch.keyCode</string>

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -23,6 +23,7 @@
     <string name="pref_key_ui_article_fontSize" translatable="false">ui.article.fontSize</string>
     <string name="pref_key_ui_article_fontSerif" translatable="false">ui.article.fontSerif</string>
     <string name="pref_key_ui_article_textAlignment_justify" translatable="false">ui.article.textAlignment.justify</string>
+    <string name="pref_key_ui_article_fullscreen" translatable="false">ui.article.fullscreen</string>
     <string name="pref_key_ui_readingSpeed" translatable="false">ui.readingSpeed</string>
     <string name="pref_key_ui_lists_sortOrder" translatable="false">ui.lists.sortOrder</string>
     <string name="pref_key_ui_tagList_sortOrder" translatable="false">ui.tagList.sortOrder</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,8 @@
     <string name="pref_desc_ui_article_fontSerif">Serif font for articles</string>
     <string name="pref_name_ui_article_textAlignment_justify">Text alignment: Justify</string>
     <string name="pref_desc_ui_article_textAlignment_justify">Stretches lines to equal width (like in newspapers)</string>
+    <string name="pref_name_ui_article_fullscreen">Fullscreen Article View</string>
+    <string name="pref_desc_ui_article_fullscreen">Hides Android\'s notification bar when reading articles</string>
     <string name="pref_name_ui_readingSpeed">Reading speed</string>
     <string name="pref_desc_ui_readingSpeed">Your reading speed (measured in words per minute). Used to calculate estimated reading time.</string>
     <string name="pref_categoryName_ui_screenScrolling">Screen scrolling</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,7 +194,7 @@
     <string name="pref_name_ui_article_textAlignment_justify">Text alignment: Justify</string>
     <string name="pref_desc_ui_article_textAlignment_justify">Stretches lines to equal width (like in newspapers)</string>
     <string name="pref_name_ui_article_fullscreen">Fullscreen Article View</string>
-    <string name="pref_desc_ui_article_fullscreen">Hides Android\'s notification bar when reading articles</string>
+    <string name="pref_desc_ui_article_fullscreen">Hides system and app bars when reading articles</string>
     <string name="pref_name_ui_readingSpeed">Reading speed</string>
     <string name="pref_desc_ui_readingSpeed">Your reading speed (measured in words per minute). Used to calculate estimated reading time.</string>
     <string name="pref_categoryName_ui_screenScrolling">Screen scrolling</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -100,11 +100,6 @@
                 android:summary="@string/pref_desc_ui_article_fontSerif"
                 android:defaultValue="false"/>
             <CheckBoxPreference
-                android:key="@string/pref_key_ui_article_fullscreen"
-                android:title="@string/pref_name_ui_article_fullscreen"
-                android:summary="@string/pref_desc_ui_article_fullscreen"
-                android:defaultValue="false"/>
-            <CheckBoxPreference
                 android:key="@string/pref_key_ui_article_textAlignment_justify"
                 android:title="@string/pref_name_ui_article_textAlignment_justify"
                 android:summary="@string/pref_desc_ui_article_textAlignment_justify"
@@ -145,6 +140,11 @@
             android:key="@string/pref_key_ui_misc_category"
             android:title="@string/pref_categoryName_ui_misc"
             android:persistent="false">
+            <CheckBoxPreference
+                android:key="@string/pref_key_ui_article_fullscreen"
+                android:title="@string/pref_name_ui_article_fullscreen"
+                android:summary="@string/pref_desc_ui_article_fullscreen"
+                android:defaultValue="false"/>
             <CheckBoxPreference
                 android:key="@string/pref_key_ui_disableTouch_enabled"
                 android:title="@string/pref_name_ui_disableTouch_enabled"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -100,6 +100,11 @@
                 android:summary="@string/pref_desc_ui_article_fontSerif"
                 android:defaultValue="false"/>
             <CheckBoxPreference
+                android:key="@string/pref_key_ui_article_fullscreen"
+                android:title="@string/pref_name_ui_article_fullscreen"
+                android:summary="@string/pref_desc_ui_article_fullscreen"
+                android:defaultValue="false"/>
+            <CheckBoxPreference
                 android:key="@string/pref_key_ui_article_textAlignment_justify"
                 android:title="@string/pref_name_ui_article_textAlignment_justify"
                 android:summary="@string/pref_desc_ui_article_textAlignment_justify"


### PR DESCRIPTION
This is a clean branch of #642 (see there for discussion, my first entry there follows as a quote).

> This pull request implements a fullscreen article view (i.e., it Android's system bar and the SupportActionBar are hided during article reading) as suggested in #114. The feature is toggable via an app-setting (in contrast to react on a tap as suggested in #569 ).
>
>This pull request also fixes #636, by only reacting on KeyEvent.ACTION_UP instead of KeyEvent.ACTION_DOWN, given that AppCompatActivity catches the key down events.
(I'm not entirely sure whether this is the true reason, but the fix works for me.)

The volume keys seem to rely on KeyEvent.ACTION_DOWN which is the reason for the if-else statement in the beginning of `dispatchKeyEvent()`. I successfully tested scrolling with a tablet with volume buttons and with an e-ink-reader with page-up / -down buttons.
  