### PR TITLE
Spelling: Mark _as_ read

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,7 +208,7 @@
     <string name="pref_desc_ui_disableTouch_enabled">Press the configured button (camera button by default) to block/unblock touch input on the reading screen (system controls are not affected)</string>
     <string name="pref_name_ui_disableTouch_keyCode">Disable touch input button</string>
     <string name="pref_desc_ui_disableTouch_keyCode">Press here to configure the button used to disable/enable touch input</string>
-    <string name="pref_name_ui_scrollOverBottom">Scroll over bottom to mark read</string>
+    <string name="pref_name_ui_scrollOverBottom">Scroll over bottom to mark as read</string>
     <string name="pref_desc_ui_scrollOverBottom">Press here to configure the number of times you need to "scroll over the bottom" to mark an article as read</string>
 
     <string name="pref_categoryName_sync">Synchronization</string>


### PR DESCRIPTION
Possibly, "Scroll beyond the bottom" or "To the bottom" instead of "Scroll over bottom"?