### PR TITLE
add scrolling via hardware keys in article lists

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListsFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListsFragment.java
@@ -219,31 +219,35 @@ public class ArticleListsFragment extends Fragment implements Sortable, Searchab
 
     public void scroll(boolean up) {
 
-        LinearLayoutManager listLayout = getCurrentFragment().recyclerViewLayoutManager;
+        ArticleListFragment currentFragment = getCurrentFragment();
 
-        int numberOfVisibleItems =
-                listLayout.findLastCompletelyVisibleItemPosition() -
-                        listLayout.findFirstCompletelyVisibleItemPosition() + 1;
+        if( currentFragment != null && currentFragment.recyclerViewLayoutManager != null) {
+            LinearLayoutManager listLayout = currentFragment.recyclerViewLayoutManager;
 
-        int oldPositionOnTop = listLayout.findFirstCompletelyVisibleItemPosition();
+            int numberOfVisibleItems =
+                    listLayout.findLastCompletelyVisibleItemPosition() -
+                            listLayout.findFirstCompletelyVisibleItemPosition() + 1;
 
-        // scroll so that as many new articles are visible than possible with one overlap
-        int newPositionOnTop;
-        if (up) {
-            newPositionOnTop = oldPositionOnTop - numberOfVisibleItems + 1;
-        } else {
-            newPositionOnTop = oldPositionOnTop + numberOfVisibleItems - 1;
+            int oldPositionOnTop = listLayout.findFirstCompletelyVisibleItemPosition();
+
+            // scroll so that as many new articles are visible than possible with one overlap
+            int newPositionOnTop;
+            if (up) {
+                newPositionOnTop = oldPositionOnTop - numberOfVisibleItems + 1;
+            } else {
+                newPositionOnTop = oldPositionOnTop + numberOfVisibleItems - 1;
+            }
+
+            if (newPositionOnTop >= listLayout.getItemCount()) {
+                newPositionOnTop = listLayout.getItemCount() - numberOfVisibleItems - 1;
+            } else if (newPositionOnTop < 0) {
+                newPositionOnTop = 0;
+            }
+
+            Log.v(TAG, " scrolling to position: " + newPositionOnTop);
+
+            listLayout.scrollToPositionWithOffset(newPositionOnTop, 0);
         }
-
-        if (newPositionOnTop >= listLayout.getItemCount()) {
-            newPositionOnTop = listLayout.getItemCount() - numberOfVisibleItems - 1;
-        } else if (newPositionOnTop < 0) {
-            newPositionOnTop = 0;
-        }
-
-        Log.v(TAG, " scrolling to position: " + newPositionOnTop);
-
-        listLayout.scrollToPositionWithOffset(newPositionOnTop, 0);
     }
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListsFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListsFragment.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
+import android.support.v7.widget.LinearLayoutManager;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -214,6 +215,35 @@ public class ArticleListsFragment extends Fragment implements Sortable, Searchab
         } else {
             updateAllLists(forceContentUpdate);
         }
+    }
+
+    public void scroll(boolean up) {
+
+        LinearLayoutManager listLayout = getCurrentFragment().recyclerViewLayoutManager;
+
+        int numberOfVisibleItems =
+                listLayout.findLastCompletelyVisibleItemPosition() -
+                        listLayout.findFirstCompletelyVisibleItemPosition() + 1;
+
+        int oldPositionOnTop = listLayout.findFirstCompletelyVisibleItemPosition();
+
+        // scroll so that as many new articles are visible than possible with one overlap
+        int newPositionOnTop;
+        if (up) {
+            newPositionOnTop = oldPositionOnTop - numberOfVisibleItems + 1;
+        } else {
+            newPositionOnTop = oldPositionOnTop + numberOfVisibleItems - 1;
+        }
+
+        if (newPositionOnTop >= listLayout.getItemCount()) {
+            newPositionOnTop = listLayout.getItemCount() - numberOfVisibleItems - 1;
+        } else if (newPositionOnTop < 0) {
+            newPositionOnTop = 0;
+        }
+
+        Log.v(TAG, " scrolling to position: " + newPositionOnTop);
+
+        listLayout.scrollToPositionWithOffset(newPositionOnTop, 0);
     }
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
@@ -897,7 +897,7 @@ public class MainActivity extends AppCompatActivity
             switch (keyCode) {
                 case KeyEvent.KEYCODE_PAGE_UP:
                 case KeyEvent.KEYCODE_PAGE_DOWN:
-                        ((ArticleListsFragment) currentFragment).scroll(keyCode == KeyEvent.KEYCODE_PAGE_UP);
+                    ((ArticleListsFragment) currentFragment).scroll(keyCode == KeyEvent.KEYCODE_PAGE_UP);
                     return true;
                 case KeyEvent.KEYCODE_VOLUME_UP:
                 case KeyEvent.KEYCODE_VOLUME_DOWN:
@@ -905,10 +905,10 @@ public class MainActivity extends AppCompatActivity
                         ((ArticleListsFragment) currentFragment).scroll(keyCode == KeyEvent.KEYCODE_VOLUME_UP);
                         return true;
                     }
+                    break;
             }
-            return true;
-        } else {
-            return false;
         }
+
+        return super.onKeyDown(keyCode, event);
     }
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
@@ -21,6 +21,7 @@ import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -890,4 +891,24 @@ public class MainActivity extends AppCompatActivity
         builder.show();
     }
 
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if(currentFragment instanceof ArticleListsFragment) {
+            switch (keyCode) {
+                case KeyEvent.KEYCODE_PAGE_UP:
+                case KeyEvent.KEYCODE_PAGE_DOWN:
+                        ((ArticleListsFragment) currentFragment).scroll(keyCode == KeyEvent.KEYCODE_PAGE_UP);
+                    return true;
+                case KeyEvent.KEYCODE_VOLUME_UP:
+                case KeyEvent.KEYCODE_VOLUME_DOWN:
+                    if (settings.isVolumeButtonsScrollingEnabled()) {
+                        ((ArticleListsFragment) currentFragment).scroll(keyCode == KeyEvent.KEYCODE_VOLUME_UP);
+                        return true;
+                    }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
This PR implements scrolling of the article list(s) via hardware buttons (volume keys or page_up / page_down). I implemented this because scrolling via touch is not nice on an e-ink display. The first / last article in the list should be the last / first article after scrolling. So a user knows, where in the list he / she is while also as much articles as possible are new in the list.

Tested with my e-ink device (page up/down) and a tablet (volume keys).

(I thought this would be easier but this took me some time. Android seems to like complicating stuff, anyway ...)