### PR TITLE
Save socket exception in log when network shuts down

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/IntentServiceBase.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/IntentServiceBase.java
@@ -61,6 +61,11 @@ public abstract class IntentServiceBase extends IntentService {
                         && e.getMessage().contains("Connection timed out")) {
                     result.setErrorType(ActionResult.ErrorType.TEMPORARY);
                     handled = true;
+                } else if(e instanceof java.net.SocketException
+                        && e.getMessage() != null
+                        && e.getMessage().contains("Software caused connection abort")) {
+                    result.setErrorType(ActionResult.ErrorType.TEMPORARY);
+                    handled = true;
                 }
             }
 


### PR DESCRIPTION
Don't send an notification with the exception to the user. Instead, save the error
in the log.

This is not finished now, as there should be a notification there to inform the user of the error. 

Update: Read Message below.