### PR TITLE
Black on black consistent in dark (high contrast) theme

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
@@ -5,6 +5,9 @@ import android.app.SearchManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.ColorStateList;
+import android.content.res.XmlResourceParser;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
@@ -34,7 +37,9 @@ import com.mikepenz.aboutlibraries.LibsBuilder;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.xmlpull.v1.XmlPullParserException;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -126,6 +131,25 @@ public class MainActivity extends AppCompatActivity
             View headerView = navigationView.getHeaderView(0);
             if(headerView != null) {
                 lastUpdateTimeView = (TextView)headerView.findViewById(R.id.lastUpdateTime);
+            }
+
+            // Set different colors for items in the navigation bar in dark (high contrast) theme
+            if (Themes.getCurrentTheme() != null && Themes.getCurrentTheme() == Themes.Theme.DARK_CONTRAST) {
+                @SuppressLint("ResourceType") XmlResourceParser parser = getResources().getXml(R.color.dark_contrast_menu_item);
+                try {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                        navigationView.setItemTextColor(ColorStateList.createFromXml(getResources(), parser, getTheme()));
+                        navigationView.setItemIconTintList(ColorStateList.createFromXml(getResources(), parser, getTheme()));
+
+                    } else {
+                        navigationView.setItemTextColor(ColorStateList.createFromXml(getResources(), parser));
+                        navigationView.setItemIconTintList(ColorStateList.createFromXml(getResources(), parser));
+                    }
+                } catch (XmlPullParserException e) {
+                    e.printStackTrace();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
         }
 

--- a/app/src/main/res/color/dark_contrast_menu_item.xml
+++ b/app/src/main/res/color/dark_contrast_menu_item.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/darkContrastGray" android:state_checked="true" />
+    <item android:color="@color/darkContrastWhite" />
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,8 +21,6 @@
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
         app:headerLayout="@layout/nav_header_main"
-        app:menu="@menu/activity_main_drawer"
-        app:itemTextColor="@color/dark_contrast_menu_item"
-        app:itemIconTint="@color/dark_contrast_menu_item"/>
+        app:menu="@menu/activity_main_drawer"/>
 
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,6 +21,8 @@
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
         app:headerLayout="@layout/nav_header_main"
-        app:menu="@menu/activity_main_drawer"/>
+        app:menu="@menu/activity_main_drawer"
+        app:itemTextColor="@color/dark_contrast_menu_item"
+        app:itemIconTint="@color/dark_contrast_menu_item"/>
 
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,4 +17,6 @@
     <color name="solarizedCyan">#2aa198</color>
     <color name="solarizedGreen">#859900</color>
     <color name="darkContrastBlack">#000000</color>
+    <color name="darkContrastWhite">#FFFFFF</color>
+    <color name="darkContrastGray">#9c9c9c</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,4 +16,5 @@
     <color name="solarizedBlue">#268bd2</color>
     <color name="solarizedCyan">#2aa198</color>
     <color name="solarizedGreen">#859900</color>
+    <color name="darkContrastBlack">#000000</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -48,8 +48,9 @@
     <style name="DarkTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Dark"/>
 
     <style name="DarkThemeContrast" parent="DarkTheme">
-        <item name="android:background">#000000</item>
+        <item name="android:windowBackground">@color/darkContrastBlack</item>
         <item name="android:textColor">#FFFFFF</item>
+        <item name="colorPrimary">#000000</item>
     </style>
 
     <style name="DarkThemeContrast.NoActionBar">


### PR DESCRIPTION
Fix #552 

Adjust color settings in this theme to use black/grey in the right situations for the app bar and the navigation bar. Also add a new color for the text of highlighted items in the navigation bar for this theme.