### PR TITLE
move jcenter as last source of dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         maven { url "https://jitpack.io" }
         maven { url 'https://maven.google.com' }
+        jcenter()
     }
 }


### PR DESCRIPTION
Because "Everyone can simply push things to jcenter in other's name/package."

https://twitter.com/PreusslerBerlin/status/1073099443585630210
--> https://blog.autsoft.hu/a-confusing-dependency/