### PR TITLE
add wallabag server 2.3.4 compatibility

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagWebService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagWebService.java
@@ -29,7 +29,7 @@ public class WallabagWebService {
     private static final Pattern WALLABAG_LOGIN_FORM_V2 = compile("/login_check\"? method=\"?post\"? name=\"?loginform\"?>");
     private static final Pattern FRAMABAG_LOGIN_FORM = compile("/login_check\" class=\"form\" method=\"post\" name=\"loginform\">");
     private static final Pattern WALLABAG_LOGOUT_LINK_V2 = compile("/logout\"?>");
-    private static final Pattern WALLABAG_LOGO_V2 = compile("alt=\"wallabag logo\" ?/?>");
+    private static final Pattern WALLABAG_LOGO_V2 = compile("alt=\"wallabag logo\"");
     private static final Pattern FRAMABAG_MARKER = compile("<span class=\"frama\">Frama</span>");
     private static final Pattern WALLABAG_LOGIN_FORM_V1 = compile("<form method=\"?post\"? action=\"?\\?login\"? name=\"?loginform\"?>");
 


### PR DESCRIPTION
Detection if a given wallabag URL is broken with 2.3.4 release of
wallabag. This was introduced with commit
https://github.com/wallabag/wallabag/commit/4c78612
and is going to be fixed with
https://github.com/wallabag/wallabag/pull/3784 which is planned to be
release with 2.3.5.

Root cause of page detection struggling is going to be raised in
https://github.com/wallabag/wallabag/issues/3808

fixes #752