### PR TITLE
fix navbar color in dark themes

### DIFF
--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -14,6 +14,10 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
+    <style name="DarkTheme" parent="Theme.AppCompat">
+        <item name="android:navigationBarColor">?attr/colorPrimary</item>
+    </style>
+
     <style name="DarkTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>


### PR DESCRIPTION
This fixes the navigation bar color in the dark themes. Before this
commit it was light colored. Now it is colored to the primary color of
dark theme, so some grey.

The problem is fixed for both styles: dark and high contrast dark.

| before  | after |
| ------------- | ------------- |
| ![screenshot_20190212-224533_wallabag](https://user-images.githubusercontent.com/97055/52670716-914de580-2f19-11e9-9f5e-015f8d6fec3b.jpg)  | ![screenshot_20190212-224456_wallabag](https://user-images.githubusercontent.com/97055/52670723-9a3eb700-2f19-11e9-96cd-9ff0ae6252d6.jpg) |
