### PR TITLE
fix image display when wbg server caches them

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/ImageCacheUtils.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/ImageCacheUtils.java
@@ -34,7 +34,7 @@ public class ImageCacheUtils {
     private static final String IMAGE_CACHE_DIR = "imagecache";
     private static final int MAXIMUM_FILE_EXT_LENGTH = 5; // incl. the dot
 
-    private static final String WALLABAG_RELATIVE_URL_PATH = "/assets/images/";
+    public static final String WALLABAG_RELATIVE_URL_PATH = "/assets/images/";
 
     private static final Pattern[] IMG_URL_PATTERNS = {
             Pattern.compile("<img[^>]+src\\s*=\\s*\"([^\"]+)\"[^>]*>", Pattern.CASE_INSENSITIVE),
@@ -302,7 +302,7 @@ public class ImageCacheUtils {
         return success;
     }
 
-    private static String getWallabagUrl() {
+    public static String getWallabagUrl() {
         if(wallabagUrl == null) {
             wallabagUrl = App.getInstance().getSettings().getUrl();
         }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -687,6 +687,16 @@ public class ReadArticleActivity extends BaseActionBarActivity {
         }
 
         String htmlContent = getHtmlContent();
+        List<String> imgURLs = ImageCacheUtils.findImageUrlsInHtml(htmlContent);
+        if(imgURLs != null && imgURLs.size() > 0) {
+            String wbgURL = ImageCacheUtils.getWallabagUrl();
+            for(String imageURL: imgURLs) {
+                if(imageURL.startsWith(ImageCacheUtils.WALLABAG_RELATIVE_URL_PATH)) {
+                    htmlContent = htmlContent.replace(imageURL, wbgURL + imageURL);
+                    Log.d(TAG, "getHtmlPage() prefixing wallabag server URL " + wbgURL + " to the image path " + imageURL);
+                }
+            }
+        }
 
         return String.format(htmlBase, cssName, classAttr, TextUtils.htmlEncode(articleTitle),
                 articleUrl, articleDomain, htmlContent);


### PR DESCRIPTION
This commit fixes the display of images when wallabag server image
caching feature is on, but this app's image downloading is not on.

fixes #624