### PR TITLE
Remove font-weight change for High Contrast theme

### DIFF
--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -20,7 +20,6 @@ body {
 
 .high-contrast {
   background: #FFF;
-  /* font-weight: 600; */
 }
 
 .serif-font {

--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -20,7 +20,7 @@ body {
 
 .high-contrast {
   background: #FFF;
-  font-weight: 600;
+  /* font-weight: 600; */
 }
 
 .serif-font {


### PR DESCRIPTION
The font-weight change in the High Contrast theme seems too aggressive to me. I suggest that the changes to background color and color are sufficient for providing the High Contrast.

I've built the app with this edit. [Click here for a screenshot of it being used](https://bikeshed.party/media/d1c6bb7c33f6f0ab186a7c10c9bf3e9f93ea7c7efe84a84ae3d83da5bf401e56.png).