### PR TITLE
Split themes and remove font-weight

### DIFF
--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -20,7 +20,6 @@ body {
 
 .high-contrast {
   background: #FFF;
-  /* font-weight: 600; */
 }
 
 .serif-font {

--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -22,6 +22,10 @@ body {
   background: #FFF;
 }
 
+.weighted-font {
+  font-weight: 600;
+}
+
 .serif-font {
   font-family: serif;
 }

--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -20,7 +20,7 @@ body {
 
 .high-contrast {
   background: #FFF;
-  font-weight: 600;
+  /* font-weight: 600; */
 }
 
 .serif-font {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -139,7 +139,7 @@ public class Settings {
                 }
 
                 Themes.Theme theme = android.os.Build.MODEL.equals("NOOK")
-                        ? Themes.Theme.LIGHT_CONTRAST : Themes.Theme.LIGHT;
+                        ? Themes.Theme.E_INK : Themes.Theme.LIGHT;
                 prefEditor.putString(context.getString(R.string.pref_key_ui_theme), theme.toString());
             }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -638,7 +638,10 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     private String getHtmlPage() {
         String cssName;
         boolean highContrast = false;
+        boolean weightedFont = false;
         switch(Themes.getCurrentTheme()) {
+            case E_INK:
+                weightedFont = true;
             case LIGHT_CONTRAST:
                 highContrast = true;
             case LIGHT:
@@ -660,6 +663,7 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
         List<String> additionalClasses = new ArrayList<>(1);
         if(highContrast) additionalClasses.add("high-contrast");
+        if(weightedFont) additionalClasses.add("weighted-font");
         if(settings.isArticleFontSerif()) additionalClasses.add("serif-font");
         if(settings.isArticleTextAlignmentJustify()) additionalClasses.add("text-align-justify");
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
@@ -62,6 +62,13 @@ public class Themes {
                 R.style.ProxyTheme
         ),
 
+        E_INK(
+                R.string.themeName_eink,
+                R.style.LightThemeContrast,
+                R.style.LightThemeContrast_NoActionBar,
+                R.style.ProxyTheme
+        ),
+
         DARK(
                 R.string.themeName_dark,
                 R.style.DarkTheme,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="noNextArticle">No more articles in current list</string>
     <string name="themeName_light">Light</string>
     <string name="themeName_light_contrast">Light (high contrast)</string>
+    <string name="themeName_eink">For e-ink displays</string>
     <string name="themeName_dark">Dark</string>
     <string name="themeName_dark_contrast">Dark (high contrast)</string>
     <string name="themeName_solarized">Solarized</string>


### PR DESCRIPTION
Splits "Light (contrast)" theme into two: one without `font-weight`, and one with it (called "For e-ink displays"). The latter may be used for further e-ink related improvements.

Incorporates #775.