### PR TITLE
Add notification channels support

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/App.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/App.java
@@ -10,6 +10,7 @@ import fr.gaulupeau.apps.InThePoche.BuildConfig;
 import fr.gaulupeau.apps.Poche.data.DbConnection;
 import fr.gaulupeau.apps.Poche.data.Settings;
 import fr.gaulupeau.apps.Poche.events.EventProcessor;
+import fr.gaulupeau.apps.Poche.ui.NotificationsHelper;
 
 public class App extends Application {
 
@@ -33,6 +34,8 @@ public class App extends Application {
         Settings.init(this);
         settings = new Settings(this);
         settings.initPreferences();
+
+        NotificationsHelper.createNotificationChannels(this);
 
         new EventProcessor(this).start();
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/events/EventProcessor.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/events/EventProcessor.java
@@ -33,6 +33,10 @@ import fr.gaulupeau.apps.Poche.service.ServiceHelper;
 import fr.gaulupeau.apps.Poche.ui.IconUnreadWidget;
 import fr.gaulupeau.apps.Poche.ui.preferences.SettingsActivity;
 
+import static fr.gaulupeau.apps.Poche.ui.NotificationsHelper.CHANNEL_ID_DOWNLOADING_ARTICLES;
+import static fr.gaulupeau.apps.Poche.ui.NotificationsHelper.CHANNEL_ID_ERRORS;
+import static fr.gaulupeau.apps.Poche.ui.NotificationsHelper.CHANNEL_ID_SYNC;
+
 // TODO: fix getters sync (AFAIK, not so important yet)
 public class EventProcessor {
 
@@ -170,7 +174,7 @@ public class EventProcessor {
 
         detailedMessage = prependAppName(detailedMessage);
 
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context)
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, CHANNEL_ID_SYNC)
                 .setSmallIcon(R.drawable.ic_action_refresh)
                 .setContentTitle(context.getString(R.string.notification_updatingArticles))
                 .setContentText(detailedMessage)
@@ -210,7 +214,7 @@ public class EventProcessor {
 
         Context context = getContext();
 
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context)
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, CHANNEL_ID_SYNC)
                 .setSmallIcon(R.drawable.ic_action_refresh)
                 .setContentTitle(context.getString(R.string.notification_sweepingDeletedArticles))
                 .setOngoing(true);
@@ -254,7 +258,7 @@ public class EventProcessor {
         if(fetchImagesNotificationBuilder == null) {
             Context context = getContext();
 
-            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context)
+            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, CHANNEL_ID_SYNC)
                     .setSmallIcon(R.drawable.ic_action_refresh)
                     .setContentTitle(context.getString(R.string.notification_downloadingImages))
                     .setOngoing(true);
@@ -308,7 +312,7 @@ public class EventProcessor {
             if(notificationBuilder == null) {
                 Context context = getContext();
 
-                notificationBuilder = new NotificationCompat.Builder(context)
+                notificationBuilder = new NotificationCompat.Builder(context, CHANNEL_ID_SYNC)
                         .setSmallIcon(R.drawable.ic_action_refresh)
                         .setContentTitle(getContext().getString(R.string.notification_syncingQueue))
                         .setOngoing(true);
@@ -349,7 +353,7 @@ public class EventProcessor {
 
         String formatString = event.getRequest().getDownloadFormat().toString();
 
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context)
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, CHANNEL_ID_DOWNLOADING_ARTICLES)
                 .setContentTitle(context.getString(R.string.downloadAsFilePathStart))
                 .setContentText(context.getString(R.string.downloadAsFileProgress, formatString))
                 .setSmallIcon(R.drawable.ic_file_download_24dp)
@@ -386,7 +390,7 @@ public class EventProcessor {
 
             PendingIntent contentIntent = PendingIntent.getActivity(context, 0, intent, 0);
 
-            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context)
+            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(context, CHANNEL_ID_DOWNLOADING_ARTICLES)
                     .setContentTitle(context.getString(R.string.downloadAsFileArticleDownloaded))
                     .setContentText(context.getString(R.string.downloadAsFileTouchToOpen))
                     .setSmallIcon(R.drawable.ic_file_download_24dp)
@@ -483,7 +487,7 @@ public class EventProcessor {
                         detailedText = prependAppName(detailedText);
 
                         NotificationCompat.Builder notificationBuilder =
-                                new NotificationCompat.Builder(context)
+                                new NotificationCompat.Builder(context, CHANNEL_ID_ERRORS)
                                         .setSmallIcon(R.drawable.ic_warning_24dp)
                                         .setContentTitle(context.getString(R.string.notification_error))
                                         .setContentText(detailedText)
@@ -510,7 +514,7 @@ public class EventProcessor {
                     detailedText = prependAppName(detailedText);
 
                     NotificationCompat.Builder notificationBuilder =
-                            new NotificationCompat.Builder(context)
+                            new NotificationCompat.Builder(context, CHANNEL_ID_ERRORS)
                                     .setSmallIcon(R.drawable.ic_warning_24dp)
                                     .setContentTitle(context.getString(serverError
                                             ? R.string.notification_serverError

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/NotificationsHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/NotificationsHelper.java
@@ -1,0 +1,82 @@
+package fr.gaulupeau.apps.Poche.ui;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationChannelGroup;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import fr.gaulupeau.apps.InThePoche.R;
+
+public class NotificationsHelper {
+
+    public static final String CHANNEL_GROUP_ID_TTS = "tts";
+    public static final String CHANNEL_GROUP_ID_SYNC = "sync";
+    public static final String CHANNEL_GROUP_ID_OTHER = "other";
+
+    public static final String CHANNEL_ID_TTS = "fr.gaulupeau.apps.Poche.tts";
+    public static final String CHANNEL_ID_SYNC = "sync";
+    public static final String CHANNEL_ID_DOWNLOADING_ARTICLES = "downloading_articles";
+    public static final String CHANNEL_ID_ERRORS = "errors";
+
+    public static void createNotificationChannels(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+
+            NotificationChannelGroup channelGroupTts = new NotificationChannelGroup(
+                    CHANNEL_GROUP_ID_TTS,
+                    context.getString(R.string.notification_channel_group_name_tts));
+            notificationManager.createNotificationChannelGroup(channelGroupTts);
+
+            NotificationChannelGroup channelGroupSync = new NotificationChannelGroup(
+                    CHANNEL_GROUP_ID_SYNC,
+                    context.getString(R.string.notification_channel_group_name_sync));
+            notificationManager.createNotificationChannelGroup(channelGroupSync);
+
+            NotificationChannelGroup channelGroupOther = new NotificationChannelGroup(
+                    CHANNEL_GROUP_ID_OTHER,
+                    context.getString(R.string.notification_channel_group_name_other));
+            notificationManager.createNotificationChannelGroup(channelGroupOther);
+
+            List<NotificationChannel> channels = new ArrayList<>();
+
+            NotificationChannel channel;
+
+            channel = new NotificationChannel(
+                    CHANNEL_ID_TTS, context.getString(R.string.notification_channel_name_tts),
+                    NotificationManager.IMPORTANCE_NONE
+            );
+            channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC);
+            channel.setGroup(channelGroupTts.getId());
+            channels.add(channel);
+
+            channel = new NotificationChannel(
+                    CHANNEL_ID_SYNC, context.getString(R.string.notification_channel_name_sync),
+                    NotificationManager.IMPORTANCE_MIN
+            );
+            channel.setGroup(channelGroupSync.getId());
+            channels.add(channel);
+
+            channel = new NotificationChannel(
+                    CHANNEL_ID_DOWNLOADING_ARTICLES, context.getString(R.string.notification_channel_name_downloading_articles),
+                    NotificationManager.IMPORTANCE_LOW
+            );
+            channel.setGroup(channelGroupSync.getId());
+            channels.add(channel);
+
+            channel = new NotificationChannel(
+                    CHANNEL_ID_ERRORS, context.getString(R.string.notification_channel_name_error),
+                    NotificationManager.IMPORTANCE_DEFAULT
+            );
+            channel.setGroup(channelGroupOther.getId());
+            channels.add(channel);
+
+            notificationManager.createNotificationChannels(channels);
+        }
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,13 @@
     <string name="notification_serverError">Server error</string>
     <string name="notification_unknownError">Unknown error</string>
     <string name="notification_expandedError">Error: %s</string>
+    <string name="notification_channel_group_name_tts">TTS</string>
+    <string name="notification_channel_group_name_sync">Synchronization</string>
+    <string name="notification_channel_group_name_other">Other</string>
+    <string name="notification_channel_name_tts">wallabag TTS</string>
+    <string name="notification_channel_name_sync">Synchronization</string>
+    <string name="notification_channel_name_downloading_articles">Downloading PDFs</string>
+    <string name="notification_channel_name_error">Errors</string>
     <string name="menu_lists_search">Search</string>
     <string name="menu_lists_changeSortOrder">Change sort order</string>
     <string name="menu_lists_sweepDeletedArticles">\"Sweep\" deleted articles</string>


### PR DESCRIPTION
#644
Thanks to reckless `targetSdkVersion` bumping we have notifications broken on Android 8+ (error messages in logcat, no notifications). It doesn't help with troubleshooting, I have to say.

This PR introduces notification channels support, which should remedy the situation.