### PR TITLE
Fix D-pad navigation in article view

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -373,19 +373,36 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                 return true;
             }
 
+            boolean scroll = false;
+            boolean up = false;
+
             switch (code) {
                 case KeyEvent.KEYCODE_PAGE_UP:
                 case KeyEvent.KEYCODE_PAGE_DOWN:
-                    scroll(code == KeyEvent.KEYCODE_PAGE_UP, screenScrollingPercent, smoothScrolling, true);
-                    return true;
+                    scroll = true;
+                    up = code == KeyEvent.KEYCODE_PAGE_UP;
+                    break;
+
+                case KeyEvent.KEYCODE_DPAD_UP:
+                case KeyEvent.KEYCODE_DPAD_DOWN:
+                case KeyEvent.KEYCODE_DPAD_LEFT:
+                case KeyEvent.KEYCODE_DPAD_RIGHT:
+                    scroll = true;
+                    up = code == KeyEvent.KEYCODE_DPAD_UP || code == KeyEvent.KEYCODE_DPAD_LEFT;
+                    break;
 
                 case KeyEvent.KEYCODE_VOLUME_UP:
                 case KeyEvent.KEYCODE_VOLUME_DOWN:
                     if (volumeButtonsScrolling) {
-                        scroll(code == KeyEvent.KEYCODE_VOLUME_UP, screenScrollingPercent, smoothScrolling, true);
-                        return true;
+                        scroll = true;
+                        up = code == KeyEvent.KEYCODE_VOLUME_UP;
                     }
                     break;
+            }
+
+            if (scroll) {
+                scroll(up, screenScrollingPercent, smoothScrolling, true);
+                return true;
             }
         }
 


### PR DESCRIPTION
Having checked some exotic input methods I discovered that D-pad navigation is broken. Made it work like `PAGE_UP` and `PAGE_DOWN`.

Commands for testing:
```shell
# adb shell input roll <dx> <dy>
adb shell input roll 0 1
adb shell input roll 0 -1
adb shell input roll 1 0
```
Those are actually `trackball` commands, but `KEYCODE_DPAD_*` codes are generated nonetheless.