### PR TITLE
Set white logo in dark themes programmatically

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
@@ -28,6 +28,7 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -132,6 +133,12 @@ public class MainActivity extends AppCompatActivity
             View headerView = navigationView.getHeaderView(0);
             if(headerView != null) {
                 lastUpdateTimeView = (TextView)headerView.findViewById(R.id.lastUpdateTime);
+            }
+
+            // Set white logo in the navigation bar in dark and dark (high contrast) theme
+            if (headerView != null && Themes.getCurrentTheme() != null && Themes.getCurrentTheme().isDark()) {
+                ImageView logo = headerView.findViewById(R.id.imageView);
+                logo.setImageDrawable(getDrawable(R.drawable.welcome_white));
             }
 
             // Set different colors for items in the navigation bar in dark (high contrast) theme

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
@@ -119,6 +119,10 @@ public class Themes {
             return proxyResId;
         }
 
+        public boolean isDark() {
+            return this == Themes.Theme.DARK || this == Themes.Theme.DARK_CONTRAST;
+        }
+
     }
 
 }


### PR DESCRIPTION
As `?attr/welcome_logo` in `nav_header_main.xml/imageView` always
selects the default, black icon, we change the icon in the `onCreate()`
method for dark themes.