### PR TITLE
File storage and full-text search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
 }
 
 greendao {
-    schemaVersion 102
+    schemaVersion 103
     daoPackage 'fr.gaulupeau.apps.Poche.data.dao'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
 }
 
 greendao {
-    schemaVersion 103
+    schemaVersion 104
     daoPackage 'fr.gaulupeau.apps.Poche.data.dao'
 }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/DbConnection.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/DbConnection.java
@@ -1,25 +1,16 @@
 package fr.gaulupeau.apps.Poche.data;
 
 import android.content.Context;
-import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Build;
 import android.util.Log;
 
-import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.greendao.database.Database;
-import org.greenrobot.greendao.database.DatabaseStatement;
 import org.greenrobot.greendao.query.QueryBuilder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import fr.gaulupeau.apps.InThePoche.BuildConfig;
 import fr.gaulupeau.apps.Poche.data.dao.DaoMaster;
 import fr.gaulupeau.apps.Poche.data.dao.DaoSession;
-import fr.gaulupeau.apps.Poche.data.dao.QueueItemDao;
-import fr.gaulupeau.apps.Poche.data.dao.entities.QueueItem;
-import fr.gaulupeau.apps.Poche.events.OfflineQueueChangedEvent;
 
 public class DbConnection {
 
@@ -38,7 +29,7 @@ public class DbConnection {
             String dbPath = new Settings(context).getDbPathForDbHelper();
 
             Log.d(TAG, "creating new db session");
-            WallabagOpenHelper dbHelper = new WallabagOpenHelper(context, dbPath, null);
+            WallabagDbOpenHelper dbHelper = new WallabagDbOpenHelper(context, dbPath, null);
             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                 dbHelper.setWriteAheadLoggingEnabled(true);
             }
@@ -67,118 +58,6 @@ public class DbConnection {
 
     private static class Holder {
         private static DaoSession session = getSession();
-    }
-
-    private static class WallabagOpenHelper extends DaoMaster.OpenHelper {
-
-        private static final String TAG = WallabagOpenHelper.class.getSimpleName();
-
-        public WallabagOpenHelper(Context context, String name, SQLiteDatabase.CursorFactory factory) {
-            super(context, name, factory);
-        }
-
-        @Override
-        public void onUpgrade(Database db, int oldVersion, int newVersion) {
-            Log.i(TAG, "Upgrading schema from version " + oldVersion + " to " + newVersion);
-
-            boolean migrationDone = false;
-            try {
-                if (oldVersion == 101 && newVersion == 102) {
-                    String[] columnsToAdd = new String[]{
-                            "\"ORIGIN_URL\" TEXT",
-                            "\"AUTHORS\" TEXT",
-                            "\"PUBLISHED_AT\" INTEGER",
-                            "\"STARRED_AT\" INTEGER",
-                            "\"IS_PUBLIC\" INTEGER",
-                            "\"PUBLIC_UID\" TEXT"
-                    };
-                    for (String col : columnsToAdd) {
-                        db.execSQL("ALTER TABLE \"ARTICLE\" ADD COLUMN " + col + ";");
-                    }
-
-                    migrationDone = true;
-                }
-            } catch (Exception e) {
-                Log.e(TAG, "Migration error", e);
-            }
-
-            if (!migrationDone) genericMigration(db, oldVersion, newVersion);
-        }
-
-        private void genericMigration(Database db, int oldVersion, int newVersion) {
-            Log.i(TAG, "genericMigration() oldVersion=" + oldVersion + ", newVersion=" + newVersion);
-
-            List<String> offlineUrls = null;
-            if(oldVersion >= 2) {
-                Cursor c = null;
-                try {
-                    c = db.rawQuery(oldVersion == 2
-                            ? "select url from offline_url order by _id"
-                            : "select extra from QUEUE_ITEM where action = 1 order by _id", null);
-
-                    offlineUrls = new ArrayList<>();
-                    while(c.moveToNext()) {
-                        if(!c.isNull(0)) offlineUrls.add(c.getString(0));
-                    }
-                } catch(Exception e) {
-                    Log.w(TAG, "Exception while migrating from version " + oldVersion, e);
-                } finally {
-                    if(c != null) {
-                        c.close();
-                    }
-                }
-            }
-
-            DaoMaster.dropAllTables(db, true);
-            onCreate(db);
-
-            Settings settings = new Settings(context);
-            settings.setFirstSyncDone(false);
-            settings.setLatestUpdatedItemTimestamp(0);
-            settings.setLatestUpdateRunTimestamp(0);
-
-            if(offlineUrls != null && !offlineUrls.isEmpty()) {
-                boolean inserted = false;
-
-                db.beginTransaction();
-                try {
-                    DatabaseStatement stmt = db.compileStatement(
-                            "insert into " + QueueItemDao.TABLENAME + "("
-                                    + QueueItemDao.Properties.Id.columnName + ", "
-                                    + QueueItemDao.Properties.QueueNumber.columnName + ", "
-                                    + QueueItemDao.Properties.Action.columnName + ", "
-                                    + QueueItemDao.Properties.Extra.columnName
-                                    + ") values(?, ?, ?, ?)");
-
-                    int i = 1;
-                    for(String url: offlineUrls) {
-                        try {
-                            stmt.bindLong(1, i);
-                            stmt.bindLong(2, i);
-                            stmt.bindLong(3, QueueItem.Action.ADD_LINK.getId());
-                            stmt.bindString(4, url);
-
-                            stmt.executeInsert();
-
-                            inserted = true;
-                        } catch(Exception e) {
-                            Log.w(TAG, "Exception while inserting an offline url: " + url, e);
-                        }
-
-                        i++;
-                    }
-
-                    db.setTransactionSuccessful();
-                } catch(Exception e) {
-                    Log.w(TAG, "Exception while inserting offline urls", e);
-                } finally {
-                    db.endTransaction();
-                }
-
-                if(inserted) EventBus.getDefault().post(new OfflineQueueChangedEvent(null));
-            }
-        }
-
     }
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/OperationsHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/OperationsHelper.java
@@ -271,6 +271,7 @@ public class OperationsHelper {
         }
 
         articleDao.delete(article);
+        StorageHelper.deleteArticleContent(articleID);
 
         notifyAboutArticleChange(article, ArticlesChangedEvent.ChangeType.DELETED);
 
@@ -286,6 +287,7 @@ public class OperationsHelper {
         DbConnection.getSession().getTagDao().deleteAll();
         DbConnection.getSession().getArticleTagsJoinDao().deleteAll();
         DbConnection.getSession().getQueueItemDao().deleteAll();
+        StorageHelper.deleteAllArticleContent();
 
         settings.setLatestUpdatedItemTimestamp(0);
         settings.setLatestUpdateRunTimestamp(0);

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
@@ -1,0 +1,133 @@
+package fr.gaulupeau.apps.Poche.data;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.util.Log;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.greendao.database.Database;
+import org.greenrobot.greendao.database.DatabaseStatement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import fr.gaulupeau.apps.Poche.data.dao.DaoMaster;
+import fr.gaulupeau.apps.Poche.data.dao.QueueItemDao;
+import fr.gaulupeau.apps.Poche.data.dao.entities.QueueItem;
+import fr.gaulupeau.apps.Poche.events.OfflineQueueChangedEvent;
+
+class WallabagDbOpenHelper extends DaoMaster.OpenHelper {
+
+    private static final String TAG = WallabagDbOpenHelper.class.getSimpleName();
+
+    private final Context context;
+
+    public WallabagDbOpenHelper(Context context, String name, SQLiteDatabase.CursorFactory factory) {
+        super(context, name, factory);
+        this.context = context;
+    }
+
+    @Override
+    public void onUpgrade(Database db, int oldVersion, int newVersion) {
+        Log.i(TAG, "Upgrading schema from version " + oldVersion + " to " + newVersion);
+
+        boolean migrationDone = false;
+        try {
+            if (oldVersion == 101 && newVersion == 102) {
+                String[] columnsToAdd = new String[]{
+                        "\"ORIGIN_URL\" TEXT",
+                        "\"AUTHORS\" TEXT",
+                        "\"PUBLISHED_AT\" INTEGER",
+                        "\"STARRED_AT\" INTEGER",
+                        "\"IS_PUBLIC\" INTEGER",
+                        "\"PUBLIC_UID\" TEXT"
+                };
+                for (String col : columnsToAdd) {
+                    db.execSQL("ALTER TABLE \"ARTICLE\" ADD COLUMN " + col + ";");
+                }
+
+                migrationDone = true;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Migration error", e);
+        }
+
+        if (!migrationDone) genericMigration(db, oldVersion, newVersion);
+    }
+
+    private void genericMigration(Database db, int oldVersion, int newVersion) {
+        Log.i(TAG, "genericMigration() oldVersion=" + oldVersion + ", newVersion=" + newVersion);
+
+        List<String> offlineUrls = null;
+        if(oldVersion >= 2) {
+            Cursor c = null;
+            try {
+                c = db.rawQuery(oldVersion == 2
+                        ? "select url from offline_url order by _id"
+                        : "select extra from QUEUE_ITEM where action = 1 order by _id", null);
+
+                offlineUrls = new ArrayList<>();
+                while(c.moveToNext()) {
+                    if(!c.isNull(0)) offlineUrls.add(c.getString(0));
+                }
+            } catch(Exception e) {
+                Log.w(TAG, "Exception while migrating from version " + oldVersion, e);
+            } finally {
+                if(c != null) {
+                    c.close();
+                }
+            }
+        }
+
+        DaoMaster.dropAllTables(db, true);
+        onCreate(db);
+
+        Settings settings = new Settings(context);
+        settings.setFirstSyncDone(false);
+        settings.setLatestUpdatedItemTimestamp(0);
+        settings.setLatestUpdateRunTimestamp(0);
+
+        if(offlineUrls != null && !offlineUrls.isEmpty()) {
+            boolean inserted = false;
+
+            db.beginTransaction();
+            try {
+                DatabaseStatement stmt = db.compileStatement(
+                        "insert into " + QueueItemDao.TABLENAME + "("
+                                + QueueItemDao.Properties.Id.columnName + ", "
+                                + QueueItemDao.Properties.QueueNumber.columnName + ", "
+                                + QueueItemDao.Properties.Action.columnName + ", "
+                                + QueueItemDao.Properties.Extra.columnName
+                                + ") values(?, ?, ?, ?)");
+
+                int i = 1;
+                for(String url: offlineUrls) {
+                    try {
+                        stmt.bindLong(1, i);
+                        stmt.bindLong(2, i);
+                        stmt.bindLong(3, QueueItem.Action.ADD_LINK.getId());
+                        stmt.bindString(4, url);
+
+                        stmt.executeInsert();
+
+                        inserted = true;
+                    } catch(Exception e) {
+                        Log.w(TAG, "Exception while inserting an offline url: " + url, e);
+                    }
+
+                    i++;
+                }
+
+                db.setTransactionSuccessful();
+            } catch(Exception e) {
+                Log.w(TAG, "Exception while inserting offline urls", e);
+            } finally {
+                db.endTransaction();
+            }
+
+            if(inserted) EventBus.getDefault().post(new OfflineQueueChangedEvent(null));
+        }
+    }
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
@@ -33,7 +33,7 @@ class WallabagDbOpenHelper extends DaoMaster.OpenHelper {
         Log.i(TAG, "Upgrading schema from version " + oldVersion + " to " + newVersion);
 
         boolean migrationDone = false;
-        if (oldVersion >= 101 && newVersion <= 102) {
+        if (oldVersion >= 101 && newVersion <= 103) {
             try {
                 if (oldVersion < 102) {
                     Log.i(TAG, "Migrating to version " + 102);
@@ -49,6 +49,13 @@ class WallabagDbOpenHelper extends DaoMaster.OpenHelper {
                     for (String col : columnsToAdd) {
                         db.execSQL("ALTER TABLE \"ARTICLE\" ADD COLUMN " + col + ";");
                     }
+                }
+
+                if (oldVersion < 103) {
+                    Log.i(TAG, "Migrating to version " + 103);
+
+                    // SQLite can't drop columns; just removing the data
+                    db.execSQL("UPDATE \"ARTICLE\" SET \"CONTENT\" = null;");
                 }
 
                 migrationDone = true;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
@@ -33,24 +33,28 @@ class WallabagDbOpenHelper extends DaoMaster.OpenHelper {
         Log.i(TAG, "Upgrading schema from version " + oldVersion + " to " + newVersion);
 
         boolean migrationDone = false;
-        try {
-            if (oldVersion == 101 && newVersion == 102) {
-                String[] columnsToAdd = new String[]{
-                        "\"ORIGIN_URL\" TEXT",
-                        "\"AUTHORS\" TEXT",
-                        "\"PUBLISHED_AT\" INTEGER",
-                        "\"STARRED_AT\" INTEGER",
-                        "\"IS_PUBLIC\" INTEGER",
-                        "\"PUBLIC_UID\" TEXT"
-                };
-                for (String col : columnsToAdd) {
-                    db.execSQL("ALTER TABLE \"ARTICLE\" ADD COLUMN " + col + ";");
+        if (oldVersion >= 101 && newVersion <= 102) {
+            try {
+                if (oldVersion < 102) {
+                    Log.i(TAG, "Migrating to version " + 102);
+
+                    String[] columnsToAdd = new String[]{
+                            "\"ORIGIN_URL\" TEXT",
+                            "\"AUTHORS\" TEXT",
+                            "\"PUBLISHED_AT\" INTEGER",
+                            "\"STARRED_AT\" INTEGER",
+                            "\"IS_PUBLIC\" INTEGER",
+                            "\"PUBLIC_UID\" TEXT"
+                    };
+                    for (String col : columnsToAdd) {
+                        db.execSQL("ALTER TABLE \"ARTICLE\" ADD COLUMN " + col + ";");
+                    }
                 }
 
                 migrationDone = true;
+            } catch (Exception e) {
+                Log.e(TAG, "Migration error", e);
             }
-        } catch (Exception e) {
-            Log.e(TAG, "Migration error", e);
         }
 
         if (!migrationDone) genericMigration(db, oldVersion, newVersion);

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
@@ -42,35 +42,12 @@ class WallabagDbOpenHelper extends DaoMaster.OpenHelper {
         Log.i(TAG, "Upgrading schema from version " + oldVersion + " to " + newVersion);
 
         boolean migrationDone = false;
-        if (oldVersion >= 101 && newVersion <= 104) {
+        if (oldVersion >= 104 && newVersion <= 104) {
             try {
-                if (oldVersion < 102) {
-                    Log.i(TAG, "Migrating to version " + 102);
-
-                    String[] columnsToAdd = new String[]{
-                            "\"ORIGIN_URL\" TEXT",
-                            "\"AUTHORS\" TEXT",
-                            "\"PUBLISHED_AT\" INTEGER",
-                            "\"STARRED_AT\" INTEGER",
-                            "\"IS_PUBLIC\" INTEGER",
-                            "\"PUBLIC_UID\" TEXT"
-                    };
-                    for (String col : columnsToAdd) {
-                        db.execSQL("ALTER TABLE \"ARTICLE\" ADD COLUMN " + col + ";");
-                    }
-                }
-
-                if (oldVersion < 103) {
-                    Log.i(TAG, "Migrating to version " + 103);
-
-                    // SQLite can't drop columns; just removing the data
-                    db.execSQL("UPDATE \"ARTICLE\" SET \"CONTENT\" = null;");
-                }
-
                 if (oldVersion < 104) {
                     Log.i(TAG, "Migrating to version " + 104);
 
-                    FtsDao.createTable(db, false);
+                    // update versions above and put your migration code here
                 }
 
                 migrationDone = true;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/FtsDao.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/FtsDao.java
@@ -1,0 +1,129 @@
+package fr.gaulupeau.apps.Poche.data.dao;
+
+import android.os.Build;
+
+import org.greenrobot.greendao.database.Database;
+import org.greenrobot.greendao.database.DatabaseStatement;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import fr.gaulupeau.apps.Poche.data.dao.entities.Article;
+
+public class FtsDao {
+
+    public static final String TABLE_NAME = "article_fts";
+
+    public static final String COLUMN_ID = "docid";
+    public static final String COLUMN_TITLE = "title";
+    public static final String COLUMN_CONTENT = "content";
+
+    public static String getQueryString() {
+        return "SELECT " + COLUMN_ID + " FROM " + TABLE_NAME + " WHERE " + TABLE_NAME + " MATCH ";
+    }
+
+    public static void createTable(Database db, boolean ifNotExists) {
+        String options = "";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            options += ", tokenize=unicode61";
+        }
+
+        String constraint = ifNotExists ? "IF NOT EXISTS ": "";
+        db.execSQL("CREATE VIRTUAL TABLE " + constraint + TABLE_NAME + " USING fts4(" +
+                COLUMN_TITLE + ", " +
+                COLUMN_CONTENT +
+                options + ");");
+    }
+
+    public static void dropTable(Database db, boolean ifExists) {
+        db.execSQL("DROP TABLE " + (ifExists ? "IF EXISTS " : "") + TABLE_NAME + ";");
+    }
+
+    public static void addArticles(Database db, Collection<Article> articles) {
+        DatabaseStatement statement = getInsertStatement(db);
+        try {
+            for (Article article : articles) {
+                int ix = 1;
+                statement.bindLong(ix++, article.getId());
+                statement.bindString(ix++, article.getTitle());
+                statement.bindString(ix++, article.getContent());
+                statement.executeInsert();
+            }
+        } finally {
+            statement.close();
+        }
+    }
+
+    public static void updateArticle(Database db, Article article) {
+        updateArticles(db, Collections.singleton(article));
+    }
+
+    public static void updateArticles(Database db, Collection<Article> articles) {
+        DatabaseStatement statement = getUpdateStatement(db);
+        DatabaseStatement titleStatement = getUpdateTitleStatement(db);
+        try {
+            for (Article article : articles) {
+                int ix = 1;
+
+                if (article.getContent() != null) {
+                    statement.bindString(ix++, article.getTitle());
+                    statement.bindString(ix++, article.getContent());
+                    statement.bindLong(ix++, article.getId());
+                    statement.execute();
+                } else {
+                    titleStatement.bindString(ix++, article.getTitle());
+                    titleStatement.bindLong(ix++, article.getId());
+                    titleStatement.execute();
+                }
+            }
+        } finally {
+            statement.close();
+            titleStatement.close();
+        }
+    }
+
+    public static void deleteArticle(Database db, long id) {
+        deleteArticles(db, Collections.singleton(id));
+    }
+
+    public static void deleteArticles(Database db, Collection<Long> ids) {
+        DatabaseStatement statement = getDeleteStatement(db);
+        try {
+            // TODO: optimize: pass array
+            for (Long id : ids) {
+                statement.bindLong(1, id);
+                statement.execute();
+            }
+        } finally {
+            statement.close();
+        }
+    }
+
+    public static void deleteAllArticles(Database db) {
+        dropTable(db, true);
+        createTable(db, true);
+    }
+
+    private static DatabaseStatement getInsertStatement(Database db) {
+        return db.compileStatement("INSERT INTO " + TABLE_NAME +
+                "(" + COLUMN_ID + ", " + COLUMN_TITLE + ", " + COLUMN_CONTENT + ")" +
+                " VALUES(?, ?, ?)");
+    }
+
+    private static DatabaseStatement getUpdateStatement(Database db) {
+        return db.compileStatement("UPDATE " + TABLE_NAME + " SET " +
+                COLUMN_TITLE + " = ?, " + COLUMN_CONTENT + " = ?" +
+                " WHERE " + COLUMN_ID + " = ?");
+    }
+
+    private static DatabaseStatement getUpdateTitleStatement(Database db) {
+        return db.compileStatement("UPDATE " + TABLE_NAME + " SET " +
+                COLUMN_TITLE + " = ?" +
+                " WHERE " + COLUMN_ID + " = ?");
+    }
+
+    private static DatabaseStatement getDeleteStatement(Database db) {
+        return db.compileStatement("DELETE FROM " + TABLE_NAME + " WHERE " + COLUMN_ID + " = ?");
+    }
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/entities/Article.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/entities/Article.java
@@ -21,6 +21,7 @@ public class Article {
     @Unique
     private Integer articleId;
 
+    @Transient
     private String content;
 
     private String title;
@@ -81,15 +82,14 @@ public class Article {
         this.id = id;
     }
 
-    @Generated(hash = 180250343)
-    public Article(Long id, Integer articleId, String content, String title, String domain, String url,
+    @Generated(hash = 1512174298)
+    public Article(Long id, Integer articleId, String title, String domain, String url,
             String originUrl, int estimatedReadingTime, String language, String previewPictureURL,
             String authors, Boolean favorite, Boolean archive, Date creationDate, Date updateDate,
             Date publishedAt, Date starredAt, Boolean isPublic, String publicUid,
             Double articleProgress, Boolean imagesDownloaded) {
         this.id = id;
         this.articleId = articleId;
-        this.content = content;
         this.title = title;
         this.domain = domain;
         this.url = url;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/Updater.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/Updater.java
@@ -26,6 +26,7 @@ import fr.gaulupeau.apps.Poche.data.StorageHelper;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleTagsJoinDao;
 import fr.gaulupeau.apps.Poche.data.dao.DaoSession;
+import fr.gaulupeau.apps.Poche.data.dao.FtsDao;
 import fr.gaulupeau.apps.Poche.data.dao.TagDao;
 import fr.gaulupeau.apps.Poche.data.dao.entities.Article;
 import fr.gaulupeau.apps.Poche.data.dao.entities.ArticleTagsJoin;
@@ -70,6 +71,7 @@ public class Updater {
         try {
             if(clean) {
                 Log.d(TAG, "update() deleting old DB entries");
+                FtsDao.deleteAllArticles(daoSession.getDatabase());
                 daoSession.getArticleTagsJoinDao().deleteAll();
                 daoSession.getArticleDao().deleteAll();
                 daoSession.getTagDao().deleteAll();
@@ -441,6 +443,10 @@ public class Updater {
                 }
                 Log.v(TAG, "performUpdate() done storing articles content");
 
+                Log.v(TAG, "performUpdate() updating articles in FTS");
+                FtsDao.updateArticles(daoSession.getDatabase(), articlesToUpdate);
+                Log.v(TAG, "performUpdate() done updating articles in FTS");
+
                 articlesToUpdate.clear();
             }
 
@@ -454,6 +460,10 @@ public class Updater {
                     StorageHelper.storeContentUnsafe(article.getArticleId(), article.getContent());
                 }
                 Log.v(TAG, "performUpdate() done storing articles content");
+
+                Log.v(TAG, "performUpdate() adding articles to FTS");
+                FtsDao.addArticles(daoSession.getDatabase(), articlesToInsert);
+                Log.v(TAG, "performUpdate() done adding articles to FTS");
 
                 articlesToInsert.clear();
             }
@@ -714,6 +724,12 @@ public class Updater {
 
         if(!articlesToDelete.isEmpty()) {
             Log.d(TAG, String.format("performSweep() deleting %d articles", articlesToDelete.size()));
+
+            Log.d(TAG, "performSweep() deleting from FTS");
+            FtsDao.deleteArticles(daoSession.getDatabase(), articlesToDelete);
+            Log.d(TAG, "performSweep() deleted from FTS");
+
+            Log.d(TAG, "performSweep() performing delete");
             articleDao.deleteByKeyInTx(articlesToDelete);
             Log.d(TAG, "performSweep() articles deleted");
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/SecondaryService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/SecondaryService.java
@@ -291,7 +291,7 @@ public class SecondaryService extends IntentServiceBase {
                         + ". articleID: " + article.getArticleId());
                 postEvent(new FetchImagesProgressEvent(actionRequest, index, totalNumber));
 
-                String content = article.getContent();
+                String content = StorageHelper.loadArticleContent(article.getArticleId());
 
                 // append preview picture URL to content to fetch it too
                 // should probably be handled separately

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
@@ -3,6 +3,7 @@ package fr.gaulupeau.apps.Poche.ui;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.database.DatabaseUtils;
 import android.os.Bundle;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
@@ -15,6 +16,7 @@ import android.widget.Toast;
 
 import org.greenrobot.greendao.query.LazyList;
 import org.greenrobot.greendao.query.QueryBuilder;
+import org.greenrobot.greendao.query.WhereCondition;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +29,7 @@ import fr.gaulupeau.apps.Poche.data.ListAdapter;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleTagsJoinDao;
 import fr.gaulupeau.apps.Poche.data.dao.DaoSession;
+import fr.gaulupeau.apps.Poche.data.dao.FtsDao;
 import fr.gaulupeau.apps.Poche.data.dao.TagDao;
 import fr.gaulupeau.apps.Poche.data.dao.entities.Article;
 import fr.gaulupeau.apps.Poche.data.dao.entities.ArticleTagsJoin;
@@ -212,7 +215,8 @@ public class ArticleListFragment extends RecyclerViewListFragment<Article> {
         }
 
         if(!TextUtils.isEmpty(searchQuery)) {
-            qb.where(ArticleDao.Properties.Title.like("%" + searchQuery + "%"));
+            qb.where(new WhereCondition.StringCondition(ArticleDao.Properties.Id.columnName + " IN (" +
+                    FtsDao.getQueryString() + DatabaseUtils.sqlEscapeString(searchQuery) + ")"));
         }
 
         switch(sortOrder) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
@@ -185,7 +185,7 @@ public class ArticleListFragment extends RecyclerViewListFragment<Article> {
             qb.offset(PER_PAGE_LIMIT * page);
         }
 
-        return removeContent(detachObjects(qb.list()));
+        return detachObjects(qb.list());
     }
 
     private QueryBuilder<Article> getQueryBuilder() {
@@ -212,8 +212,7 @@ public class ArticleListFragment extends RecyclerViewListFragment<Article> {
         }
 
         if(!TextUtils.isEmpty(searchQuery)) {
-            qb.whereOr(ArticleDao.Properties.Title.like("%" + searchQuery + "%"),
-                    ArticleDao.Properties.Content.like("%" + searchQuery + "%"));
+            qb.where(ArticleDao.Properties.Title.like("%" + searchQuery + "%"));
         }
 
         switch(sortOrder) {
@@ -236,15 +235,6 @@ public class ArticleListFragment extends RecyclerViewListFragment<Article> {
     private List<Article> detachObjects(List<Article> articles) {
         for(Article article: articles) {
             articleDao.detach(article);
-        }
-
-        return articles;
-    }
-
-    // removes content from article objects in order to free memory
-    private List<Article> removeContent(List<Article> articles) {
-        for(Article article: articles) {
-            article.setContent(null);
         }
 
         return articles;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -46,6 +46,7 @@ import org.greenrobot.eventbus.ThreadMode;
 import org.greenrobot.greendao.query.QueryBuilder;
 
 import fr.gaulupeau.apps.InThePoche.BuildConfig;
+import fr.gaulupeau.apps.Poche.data.StorageHelper;
 import fr.gaulupeau.apps.Poche.events.ArticlesChangedEvent;
 import fr.gaulupeau.apps.Poche.events.FeedsChangedEvent;
 import fr.gaulupeau.apps.Poche.network.ImageCacheUtils;
@@ -770,7 +771,7 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     }
 
     private String getHtmlContent() {
-        String htmlContent = article.getContent();
+        String htmlContent = StorageHelper.loadArticleContent(article.getArticleId());
 
         int estimatedReadingTime = article.getEstimatedReadingTime(settings.getReadingSpeed());
         String estimatedReadingTimeString = getString(R.string.content_estimatedReadingTime,


### PR DESCRIPTION
The long awaited (by me) file storage that should banish the `CursorWindow` error (fixes #413).
All it does is moves `content` from the `article` table to html files (one file per article).

I haven't benchmarked it, but it should improve article lists performance, because the content is no longer loaded when it is not needed.

Naturally, this breaks content-based "search". So I also implemented full-text search based on the [SQLite's FTS extension](https://www.sqlite.org/fts3.html) (improves #113). [Advanced queries](https://www.sqlite.org/fts3.html#full_text_index_queries) should be available now.

Currently `title` and `content` are separately indexed by FTS (can be used in queries like `title:linux`, see the previous link). **I guess I should add some other fields to the index, not quite sure which though.**

As a result the content is actually stored both in files (for the app to use) and in the DB (in the FTS tables). There is an option to use [contentless FTS tables](https://www.sqlite.org/fts3.html#_contentless_fts4_tables_), but they only support `insert` - working around this isn't worth the trouble.

I was struggling to come up with a proper not-too-complicated migration, so I just made this change not migratable - the DB is wiped (not uploaded URLs are preserved) - a synchronization is needed after upgrade.

Undoubtedly, there's still room for improvement, but I think this is pretty much ready. (I'll take another look later, though.)