### PR TITLE
Lazy loading of article `content` and full-text search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
 }
 
 greendao {
-    schemaVersion 103
+    schemaVersion 104
     daoPackage 'fr.gaulupeau.apps.Poche.data.dao'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ android {
 }
 
 greendao {
-    schemaVersion 104
+    schemaVersion 105
     daoPackage 'fr.gaulupeau.apps.Poche.data.dao'
 }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/OperationsHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/OperationsHelper.java
@@ -11,6 +11,7 @@ import java.util.List;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleTagsJoinDao;
 import fr.gaulupeau.apps.Poche.data.dao.DaoSession;
+import fr.gaulupeau.apps.Poche.data.dao.FtsDao;
 import fr.gaulupeau.apps.Poche.data.dao.TagDao;
 import fr.gaulupeau.apps.Poche.data.dao.entities.Article;
 import fr.gaulupeau.apps.Poche.data.dao.entities.ArticleTagsJoin;
@@ -286,6 +287,7 @@ public class OperationsHelper {
     public static void wipeDB(Settings settings) {
         DaoSession daoSession = getDaoSession();
 
+        FtsDao.deleteAllArticles(daoSession.getDatabase());
         daoSession.getArticleContentDao().deleteAll();
         daoSession.getArticleDao().deleteAll();
         daoSession.getTagDao().deleteAll();

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/OperationsHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/OperationsHelper.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import fr.gaulupeau.apps.Poche.data.dao.ArticleDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleTagsJoinDao;
+import fr.gaulupeau.apps.Poche.data.dao.DaoSession;
 import fr.gaulupeau.apps.Poche.data.dao.TagDao;
 import fr.gaulupeau.apps.Poche.data.dao.entities.Article;
 import fr.gaulupeau.apps.Poche.data.dao.entities.ArticleTagsJoin;
@@ -270,6 +271,7 @@ public class OperationsHelper {
             return; // not an error?
         }
 
+        getDaoSession().getArticleContentDao().deleteByKey(article.getId());
         articleDao.delete(article);
 
         notifyAboutArticleChange(article, ArticlesChangedEvent.ChangeType.DELETED);
@@ -282,10 +284,13 @@ public class OperationsHelper {
     }
 
     public static void wipeDB(Settings settings) {
-        DbConnection.getSession().getArticleDao().deleteAll();
-        DbConnection.getSession().getTagDao().deleteAll();
-        DbConnection.getSession().getArticleTagsJoinDao().deleteAll();
-        DbConnection.getSession().getQueueItemDao().deleteAll();
+        DaoSession daoSession = getDaoSession();
+
+        daoSession.getArticleContentDao().deleteAll();
+        daoSession.getArticleDao().deleteAll();
+        daoSession.getTagDao().deleteAll();
+        daoSession.getArticleTagsJoinDao().deleteAll();
+        daoSession.getQueueItemDao().deleteAll();
 
         settings.setLatestUpdatedItemTimestamp(0);
         settings.setLatestUpdateRunTimestamp(0);
@@ -295,7 +300,11 @@ public class OperationsHelper {
     }
 
     private static ArticleDao getArticleDao() {
-        return DbConnection.getSession().getArticleDao();
+        return getDaoSession().getArticleDao();
+    }
+
+    private static DaoSession getDaoSession() {
+        return DbConnection.getSession();
     }
 
     private static Article getArticle(int articleID, ArticleDao articleDao) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/WallabagDbOpenHelper.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import fr.gaulupeau.apps.Poche.data.dao.ArticleTagsJoinDao;
+import fr.gaulupeau.apps.Poche.data.dao.ArticleContentDao;
+import fr.gaulupeau.apps.Poche.data.dao.ArticleDao;
 import fr.gaulupeau.apps.Poche.data.dao.DaoMaster;
 import fr.gaulupeau.apps.Poche.data.dao.QueueItemDao;
 import fr.gaulupeau.apps.Poche.data.dao.entities.QueueItem;
@@ -34,7 +36,7 @@ class WallabagDbOpenHelper extends DaoMaster.OpenHelper {
         Log.i(TAG, "Upgrading schema from version " + oldVersion + " to " + newVersion);
 
         boolean migrationDone = false;
-        if (oldVersion >= 101 && newVersion <= 103) {
+        if (oldVersion >= 101 && newVersion <= 104) {
             try {
                 if (oldVersion < 102) {
                     Log.i(TAG, "Migrating to version " + 102);
@@ -61,6 +63,21 @@ class WallabagDbOpenHelper extends DaoMaster.OpenHelper {
                     db.execSQL("create index IDX_ARTICLE_TAGS_JOIN_TAG_ID on " +
                             ArticleTagsJoinDao.TABLENAME +
                             " (" + ArticleTagsJoinDao.Properties.TagId.columnName + " asc);");
+                }
+
+                if (oldVersion < 104) {
+                    Log.i(TAG, "Migrating to version " + 104);
+
+                    ArticleContentDao.createTable(db, false);
+
+                    db.execSQL("insert into " + ArticleContentDao.TABLENAME +
+                            "(" + ArticleContentDao.Properties.Id.columnName +
+                            ", " + ArticleContentDao.Properties.Content.columnName + ")" +
+                            " select " + ArticleDao.Properties.Id.columnName + ", CONTENT" +
+                            " from " + ArticleDao.TABLENAME);
+
+                    // SQLite can't drop columns; just removing the data
+                    db.execSQL("update " + ArticleContentDao.TABLENAME + " set CONTENT = null;");
                 }
 
                 migrationDone = true;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/FtsDao.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/FtsDao.java
@@ -1,0 +1,193 @@
+package fr.gaulupeau.apps.Poche.data.dao;
+
+import android.os.Build;
+
+import org.greenrobot.greendao.database.Database;
+
+public class FtsDao {
+
+    public static final String TABLE_NAME = "article_fts";
+
+    public static final String COLUMN_ID = "docid";
+    public static final String COLUMN_TITLE = "title";
+    public static final String COLUMN_CONTENT = "content";
+
+    public static final String VIEW_FOR_FTS_NAME = "article_content_for_fts";
+
+    private static final String[] TRIGGER_NAMES = new String[]{
+            "article_added_insert_fts_tr",
+            "article_added_update_fts_tr",
+            "article_content_added_insert_fts_tr",
+            "article_content_added_update_fts_tr",
+            "article_before_updated_tr",
+            "article_after_updated_tr",
+            "article_content_before_updated_tr",
+            "article_content_after_updated_tr",
+            "article_before_delete_tr",
+            "article_after_delete_tr",
+            "article_content_before_delete_tr",
+            "article_content_after_delete_tr"
+    };
+
+    public static String getQueryString() {
+        return "select " + COLUMN_ID + " from " + TABLE_NAME + " where " + TABLE_NAME + " match ";
+    }
+
+    public static void createAll(Database db, boolean ifNotExists) {
+        createViewForFts(db, ifNotExists);
+        createTable(db, ifNotExists);
+        createTriggers(db, ifNotExists);
+    }
+
+    public static void dropAll(Database db, boolean ifExists) {
+        dropTriggers(db, ifExists);
+        dropTable(db, ifExists);
+        dropViewForFts(db, ifExists);
+    }
+
+    public static void deleteAllArticles(Database db) {
+        dropTable(db, true);
+        createTable(db, true);
+    }
+
+    private static void createTable(Database db, boolean ifNotExists) {
+        String options = ", content=\"" + VIEW_FOR_FTS_NAME + "\"";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            options += ", tokenize=unicode61";
+        }
+
+        db.execSQL("create virtual table " + getIfNotExistsConstraint(ifNotExists) +
+                TABLE_NAME + " using fts4(" +
+                COLUMN_TITLE + ", " +
+                COLUMN_CONTENT +
+                options + ");");
+    }
+
+    private static void dropTable(Database db, boolean ifExists) {
+        db.execSQL("drop table " + getIfExistsConstraint(ifExists) + TABLE_NAME + ";");
+    }
+
+    private static void createViewForFts(Database db, boolean ifNotExists) {
+        final String id = ArticleDao.Properties.Id.columnName;
+
+        String viewQuery = "select a." + id + " rowid" +
+                ", a." + ArticleDao.Properties.Title.columnName +
+                ", c." + ArticleContentDao.Properties.Content.columnName +
+                " from " + ArticleDao.TABLENAME + " a join " + ArticleContentDao.TABLENAME + " c" +
+                " using (" + id + ")";
+
+        String createViewQuery = "create view " + getIfNotExistsConstraint(ifNotExists) +
+                VIEW_FOR_FTS_NAME + " as " + viewQuery;
+
+        db.execSQL(createViewQuery);
+    }
+
+    private static void dropViewForFts(Database db, boolean ifExists) {
+        db.execSQL("drop view " + getIfExistsConstraint(ifExists) + VIEW_FOR_FTS_NAME);
+    }
+
+    private static void createTriggers(Database db, boolean ifNotExists) {
+        final String sqlId = "rowid";
+        final String daoId = ArticleDao.Properties.Id.columnName;
+        final String fts = TABLE_NAME;
+        final String ftsId = COLUMN_ID;
+        final String ftsTitle = COLUMN_TITLE;
+        final String ftsContent = COLUMN_CONTENT;
+        final String article =  ArticleDao.TABLENAME;
+        final String articleTitle =  ArticleDao.Properties.Title.columnName;
+        final String articleContent = ArticleContentDao.TABLENAME;
+        final String articleContentContent = ArticleContentDao.Properties.Content.columnName;
+
+        String[] triggers = {
+                "after insert on " + article +
+                        " when not exists (select " + ftsId + " from " + fts + " where " + ftsId + " = new." + sqlId + ")" +
+                        " begin" +
+                        "   insert into " + fts + "(" + ftsId + ", " + ftsTitle + ", " + ftsContent + ")" +
+                        "     values(new." + sqlId + ", new." + articleTitle + "," +
+                        "       coalesce((select " + articleContentContent + " from " + articleContent +
+                        "         where " + daoId + " = new." + sqlId + "), null)" +
+                        "     );" +
+                        " end",
+                "after insert on " + article +
+                        " when exists (select " + ftsId + " from " + fts + " where " + ftsId + " = new." + sqlId + ")" +
+                        " begin" +
+                        "   update " + fts + " set " + ftsTitle + " = new." + articleTitle +
+                        "     where " + ftsId + " = new." + sqlId + ";" +
+                        " end",
+                "after insert on " + articleContent +
+                        " when not exists (select " + ftsId + " from " + fts + " where " + ftsId + " = new." + sqlId + ")" +
+                        " begin" +
+                        "   insert into " + fts + "(" + ftsId + ", " + ftsTitle + ", " + ftsContent + ")" +
+                        "     values(new." + sqlId + ", coalesce((select " + articleTitle + " from " + article +
+                        "       where " + daoId + " = new." + sqlId + "), null), new." + articleContentContent + ");" +
+                        " end",
+                "after insert on " + articleContent +
+                        " when exists (select " + ftsId + " from " + fts + " where " + ftsId + " = new." + sqlId + ")" +
+                        " begin" +
+                        "   update " + fts + " set " + ftsTitle + " = coalesce((select " + articleTitle + " from " + article +
+                        "       where " + daoId + " = new." + sqlId + "), null), " + ftsContent + " = new." + articleContentContent +
+                        "     where " + ftsId + " = new." + sqlId + ";" +
+                        " end",
+                "before update of " + articleTitle + " on " + article +
+                        " begin" +
+                        "   update " + fts + " set " + ftsTitle + " = null where " + ftsId + " = old." + sqlId + ";" +
+                        " end",
+                "after update of " + articleTitle + " on " + article +
+                        " begin" +
+                        "   update " + fts + " set " + ftsTitle + " = new." + articleTitle +
+                        "     where " + ftsId + " = new." + sqlId + ";" +
+                        " end",
+                "before update of " + articleContentContent + " on " + articleContent +
+                        " begin" +
+                        "   update " + fts + " set " + ftsContent + " = null" +
+                        "     where " + ftsId + " = old." + sqlId + ";" +
+                        " end",
+                "after update of " + articleContentContent + " on " + articleContent +
+                        " begin" +
+                        "   update " + fts + " set " + ftsContent + " = new." + articleContentContent +
+                        "     where " + ftsId + " = new." + sqlId + ";" +
+                        " end",
+                "before delete on " + article +
+                        " when exists (select " + daoId + " from " + articleContent + " where " + daoId + " = old." + sqlId + ")" +
+                        " begin" +
+                        "   update " + fts + " set " + ftsTitle + " = null where " + ftsId + " = old." + sqlId + ";" +
+                        " end",
+                "before delete on " + article +
+                        " when not exists (select " + daoId + " from " + articleContent + " where " + daoId + " = old." + sqlId + ")" +
+                        " begin" +
+                        "   delete from " + fts + " where " + ftsId + " = old." + sqlId + ";" +
+                        " end",
+                "before delete on " + articleContent +
+                        " when exists (select " + daoId + " from " + article + " where " + daoId + " = old." + sqlId + ")" +
+                        " begin" +
+                        "   update " + fts + " set " + ftsContent + " = null where " + ftsId + " = old." + sqlId + ";" +
+                        " end",
+                "before delete on " + articleContent +
+                        " when not exists (select " + daoId + " from " + article + " where " + daoId + " = old." + sqlId + ")" +
+                        " begin" +
+                        "   delete from " + fts + " where " + ftsId + " = old." + sqlId + ";" +
+                        " end"
+        };
+
+        for (int i = 0; i < triggers.length; i++) {
+            String triggerBody = triggers[i];
+            db.execSQL("create trigger " + getIfNotExistsConstraint(ifNotExists) +
+                    TRIGGER_NAMES[i] + " " + triggerBody);
+        }
+    }
+
+    private static void dropTriggers(Database db, boolean ifExists) {
+        for (String trigger : TRIGGER_NAMES) {
+            db.execSQL("drop trigger " + getIfExistsConstraint(ifExists) + trigger);
+        }
+    }
+
+    private static String getIfNotExistsConstraint(boolean ifNotExists) {
+        return ifNotExists ? "if not exists ": "";
+    }
+
+    private static String getIfExistsConstraint(boolean ifExists) {
+        return ifExists ? "if exists " : "";
+    }
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/entities/Article.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/entities/Article.java
@@ -8,6 +8,7 @@ import org.greenrobot.greendao.DaoException;
 import fr.gaulupeau.apps.Poche.data.dao.DaoSession;
 import fr.gaulupeau.apps.Poche.data.dao.TagDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleDao;
+import fr.gaulupeau.apps.Poche.data.dao.ArticleContentDao;
 
 /**
  * Entity mapped to table "ARTICLE".
@@ -21,7 +22,8 @@ public class Article {
     @Unique
     private Integer articleId;
 
-    private String content;
+    @Transient
+    private ArticleContent content;
 
     private String title;
 
@@ -81,15 +83,14 @@ public class Article {
         this.id = id;
     }
 
-    @Generated(hash = 180250343)
-    public Article(Long id, Integer articleId, String content, String title, String domain, String url,
+    @Generated(hash = 1512174298)
+    public Article(Long id, Integer articleId, String title, String domain, String url,
             String originUrl, int estimatedReadingTime, String language, String previewPictureURL,
             String authors, Boolean favorite, Boolean archive, Date creationDate, Date updateDate,
             Date publishedAt, Date starredAt, Boolean isPublic, String publicUid,
             Double articleProgress, Boolean imagesDownloaded) {
         this.id = id;
         this.articleId = articleId;
-        this.content = content;
         this.title = title;
         this.domain = domain;
         this.url = url;
@@ -127,11 +128,37 @@ public class Article {
     }
 
     public String getContent() {
-        return content;
+        return getArticleContent().getContent();
     }
 
     public void setContent(String content) {
-        this.content = content;
+        getArticleContent().setContent(content);
+    }
+
+    public ArticleContent getArticleContent() {
+        ArticleContent content = this.content;
+        if (content == null) {
+            if (id == null) {
+                throw new IllegalStateException("Can't fetch content for a not persisted Article");
+            }
+
+            DaoSession daoSession = this.daoSession;
+            if (daoSession == null) {
+                throw new DaoException("Entity is detached from DAO context");
+            }
+
+            ArticleContentDao targetDao = daoSession.getArticleContentDao();
+            this.content = content = targetDao.load(id);
+        }
+        return content;
+    }
+
+    public void setArticleContent(ArticleContent articleContent) {
+        this.content = articleContent;
+    }
+
+    public boolean isArticleContentLoaded() {
+        return content != null;
     }
 
     public String getTitle() {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/entities/ArticleContent.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/entities/ArticleContent.java
@@ -1,0 +1,40 @@
+package fr.gaulupeau.apps.Poche.data.dao.entities;
+
+import org.greenrobot.greendao.annotation.Entity;
+import org.greenrobot.greendao.annotation.Id;
+import org.greenrobot.greendao.annotation.Generated;
+
+@Entity
+public class ArticleContent {
+
+    @Id
+    private Long id;
+
+    private String content;
+
+    @Generated(hash = 1175279025)
+    public ArticleContent(Long id, String content) {
+        this.id = id;
+        this.content = content;
+    }
+
+    @Generated(hash = 949142728)
+    public ArticleContent() {}
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getContent() {
+        return this.content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/Updater.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/Updater.java
@@ -28,6 +28,7 @@ import fr.gaulupeau.apps.Poche.data.dao.ArticleContentDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleTagsJoinDao;
 import fr.gaulupeau.apps.Poche.data.dao.DaoSession;
+import fr.gaulupeau.apps.Poche.data.dao.FtsDao;
 import fr.gaulupeau.apps.Poche.data.dao.TagDao;
 import fr.gaulupeau.apps.Poche.data.dao.entities.Article;
 import fr.gaulupeau.apps.Poche.data.dao.entities.ArticleContent;
@@ -73,6 +74,7 @@ public class Updater {
         try {
             if(clean) {
                 Log.d(TAG, "update() deleting old DB entries");
+                FtsDao.deleteAllArticles(daoSession.getDatabase());
                 daoSession.getArticleTagsJoinDao().deleteAll();
                 daoSession.getArticleContentDao().deleteAll();
                 daoSession.getArticleDao().deleteAll();

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/Updater.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/Updater.java
@@ -24,11 +24,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import fr.gaulupeau.apps.Poche.data.dao.ArticleContentDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleTagsJoinDao;
 import fr.gaulupeau.apps.Poche.data.dao.DaoSession;
 import fr.gaulupeau.apps.Poche.data.dao.TagDao;
 import fr.gaulupeau.apps.Poche.data.dao.entities.Article;
+import fr.gaulupeau.apps.Poche.data.dao.entities.ArticleContent;
 import fr.gaulupeau.apps.Poche.data.dao.entities.ArticleTagsJoin;
 import fr.gaulupeau.apps.Poche.data.dao.entities.Tag;
 import fr.gaulupeau.apps.Poche.events.ArticlesChangedEvent;
@@ -72,6 +74,7 @@ public class Updater {
             if(clean) {
                 Log.d(TAG, "update() deleting old DB entries");
                 daoSession.getArticleTagsJoinDao().deleteAll();
+                daoSession.getArticleContentDao().deleteAll();
                 daoSession.getArticleDao().deleteAll();
                 daoSession.getTagDao().deleteAll();
 
@@ -118,6 +121,7 @@ public class Updater {
                 full, latestUpdatedItemTimestamp));
 
         ArticleDao articleDao = daoSession.getArticleDao();
+        ArticleContentDao articleContentDao = daoSession.getArticleContentDao();
         TagDao tagDao = daoSession.getTagDao();
         ArticleTagsJoinDao articleTagsJoinDao = daoSession.getArticleTagsJoinDao();
 
@@ -167,6 +171,8 @@ public class Updater {
 
         List<Article> articlesToUpdate = new ArrayList<>();
         List<Article> articlesToInsert = new ArrayList<>();
+        List<ArticleContent> articleContentToUpdate = new ArrayList<>();
+        List<ArticleContent> articleContentToInsert = new ArrayList<>();
         Set<Tag> tagsToUpdate = new HashSet<>();
         List<Tag> tagsToInsert = new ArrayList<>();
         Map<Article, List<Tag>> articleTagJoinsToRemove = new HashMap<>();
@@ -190,6 +196,8 @@ public class Updater {
 
             articlesToUpdate.clear();
             articlesToInsert.clear();
+            articleContentToUpdate.clear();
+            articleContentToInsert.clear();
             tagsToUpdate.clear();
             tagsToInsert.clear();
             articleTagJoinsToRemove.clear();
@@ -214,7 +222,7 @@ public class Updater {
                     article = new Article(null);
                     article.setArticleId(id);
                     article.setTitle(apiArticle.title);
-                    article.setContent(apiArticle.content);
+                    article.setArticleContent(new ArticleContent(null, apiArticle.content));
                     article.setDomain(apiArticle.domainName);
                     article.setUrl(apiArticle.url);
                     article.setOriginUrl(apiArticle.originUrl);
@@ -238,6 +246,7 @@ public class Updater {
                 if(existing) {
                     if(!equalOrEmpty(article.getContent(), apiArticle.content)) {
                         article.setContent(apiArticle.content);
+                        articleContentToUpdate.add(article.getArticleContent());
                         articleChanges.add(ChangeType.CONTENT_CHANGED);
                     }
                     if(!equalOrEmpty(article.getTitle(), apiArticle.title)) {
@@ -428,12 +437,34 @@ public class Updater {
                 articlesToUpdate.clear();
             }
 
+            if(!articleContentToUpdate.isEmpty()) {
+                Log.v(TAG, "performUpdate() performing articleContentDao.updateInTx()");
+                articleContentDao.updateInTx(articleContentToUpdate);
+                Log.v(TAG, "performUpdate() done articleContentDao.updateInTx()");
+
+                articleContentToUpdate.clear();
+            }
+
             if(!articlesToInsert.isEmpty()) {
                 Log.v(TAG, "performUpdate() performing articleDao.insertInTx()");
                 articleDao.insertInTx(articlesToInsert);
                 Log.v(TAG, "performUpdate() done articleDao.insertInTx()");
 
+                for (Article article : articlesToInsert) {
+                    ArticleContent content = article.getArticleContent();
+                    content.setId(article.getId());
+                    articleContentToInsert.add(content);
+                }
+
                 articlesToInsert.clear();
+            }
+
+            if(!articleContentToInsert.isEmpty()) {
+                Log.v(TAG, "performUpdate() performing articleContentDao.insertInTx()");
+                articleContentDao.insertInTx(articleContentToInsert);
+                Log.v(TAG, "performUpdate() done articleContentDao.insertInTx()");
+
+                articleContentToInsert.clear();
             }
 
             if(!tagsToUpdate.isEmpty()) {
@@ -521,7 +552,9 @@ public class Updater {
 
     private void fixArticleNullValues(Article article) {
         if(article.getTitle() == null) article.setTitle("");
-        if(article.getContent() == null) article.setContent("");
+        if(article.isArticleContentLoaded() && article.getContent() == null) {
+            article.setContent("");
+        }
         if(article.getDomain() == null) article.setDomain("");
         if(article.getUrl() == null) article.setUrl("");
         if(article.getLanguage() == null) article.setLanguage("");
@@ -690,6 +723,12 @@ public class Updater {
 
         if(!articlesToDelete.isEmpty()) {
             Log.d(TAG, String.format("performSweep() deleting %d articles", articlesToDelete.size()));
+
+            Log.d(TAG, "performSweep() performing content delete");
+            daoSession.getArticleContentDao().deleteByKeyInTx(articlesToDelete);
+            Log.d(TAG, "performSweep() articles content deleted");
+
+            Log.d(TAG, "performSweep() performing articles delete");
             articleDao.deleteByKeyInTx(articlesToDelete);
             Log.d(TAG, "performSweep() articles deleted");
         }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
@@ -3,6 +3,7 @@ package fr.gaulupeau.apps.Poche.ui;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.database.DatabaseUtils;
 import android.os.Bundle;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
@@ -15,6 +16,7 @@ import android.widget.Toast;
 
 import org.greenrobot.greendao.query.LazyList;
 import org.greenrobot.greendao.query.QueryBuilder;
+import org.greenrobot.greendao.query.WhereCondition;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +29,7 @@ import fr.gaulupeau.apps.Poche.data.ListAdapter;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleDao;
 import fr.gaulupeau.apps.Poche.data.dao.ArticleTagsJoinDao;
 import fr.gaulupeau.apps.Poche.data.dao.DaoSession;
+import fr.gaulupeau.apps.Poche.data.dao.FtsDao;
 import fr.gaulupeau.apps.Poche.data.dao.TagDao;
 import fr.gaulupeau.apps.Poche.data.dao.entities.Article;
 import fr.gaulupeau.apps.Poche.data.dao.entities.ArticleTagsJoin;
@@ -212,7 +215,8 @@ public class ArticleListFragment extends RecyclerViewListFragment<Article> {
         }
 
         if(!TextUtils.isEmpty(searchQuery)) {
-            qb.where(ArticleDao.Properties.Title.like("%" + searchQuery + "%"));
+            qb.where(new WhereCondition.StringCondition(ArticleDao.Properties.Id.columnName + " IN (" +
+                    FtsDao.getQueryString() + DatabaseUtils.sqlEscapeString(searchQuery) + ")"));
         }
 
         switch(sortOrder) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
@@ -185,7 +185,7 @@ public class ArticleListFragment extends RecyclerViewListFragment<Article> {
             qb.offset(PER_PAGE_LIMIT * page);
         }
 
-        return removeContent(detachObjects(qb.list()));
+        return detachObjects(qb.list());
     }
 
     private QueryBuilder<Article> getQueryBuilder() {
@@ -212,8 +212,7 @@ public class ArticleListFragment extends RecyclerViewListFragment<Article> {
         }
 
         if(!TextUtils.isEmpty(searchQuery)) {
-            qb.whereOr(ArticleDao.Properties.Title.like("%" + searchQuery + "%"),
-                    ArticleDao.Properties.Content.like("%" + searchQuery + "%"));
+            qb.where(ArticleDao.Properties.Title.like("%" + searchQuery + "%"));
         }
 
         switch(sortOrder) {
@@ -236,15 +235,6 @@ public class ArticleListFragment extends RecyclerViewListFragment<Article> {
     private List<Article> detachObjects(List<Article> articles) {
         for(Article article: articles) {
             articleDao.detach(article);
-        }
-
-        return articles;
-    }
-
-    // removes content from article objects in order to free memory
-    private List<Article> removeContent(List<Article> articles) {
-        for(Article article: articles) {
-            article.setContent(null);
         }
 
         return articles;


### PR DESCRIPTION
This PR:
* Makes `content` load lazily. To achieve that I had to move `content` to a separate table - I don't know how to make a field load lazily with Greendao otherwise. This probably fixes #413. Also improves performance of lists.
* Adds full-text search based on the [SQLite's FTS extension](https://www.sqlite.org/fts3.html) (improves #113). [Advanced queries](https://www.sqlite.org/fts3.html#full_text_index_queries) should be available now.
Currently `title` and `content` are separately indexed by FTS (can be used in queries like `title:linux`, see the previous link).

This PR implements [external content FTS tables](https://www.sqlite.org/fts3.html#_external_content_fts4_tables_), so there's no data duplication as in #871. Updating of FTS table is implemented using triggers. A lot of triggers \**sigh*\*.

The features are not so closely related, but seeing how FTS adds constraints, I decided to implement both in one PR.