### PR TITLE
Fix WebView crash on Android 5

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -8,6 +8,7 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -149,6 +150,18 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     private boolean isResumed;
     private boolean onPageFinishedCallPostponedUntilResume;
     private boolean loadingFinished;
+
+    // TODO: remove after updating to ~"androidx.appcompat:appcompat:1.2.0"
+    // https://issuetracker.google.com/issues/141132133
+    // https://stackoverflow.com/q/58028821
+    // workaround: https://github.com/ankidroid/Anki-Android/issues/5507#issuecomment-543501300
+    @Override
+    public void applyOverrideConfiguration(Configuration overrideConfiguration) {
+        if (Build.VERSION.SDK_INT >= 21 && Build.VERSION.SDK_INT <= 25) {
+            return;
+        }
+        super.applyOverrideConfiguration(overrideConfiguration);
+    }
 
     public void onCreate(Bundle savedInstanceState) {
 


### PR DESCRIPTION
I was testing stuff on an Android 5 emulator and encountered [this bug](https://stackoverflow.com/q/58028821).

The bug is: opening `ReadArticleActivity` results in app crash caused by missing resources required to inflate WebView.

Caused by `androidx.appcompat:appcompat:1.1.0` or `androidx.appcompat:appcompat-resources:1.1.0`. Downgrading appcompat to 1.0.2 didn't work, because of the libraries' transitive dependencies.

The workaround should be removed if it will be fixed in `appcompat/appcompat-resources:1.2.0`.