### PR TITLE
Decode HTML entities in title

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/ListAdapter.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/ListAdapter.java
@@ -2,6 +2,9 @@ package fr.gaulupeau.apps.Poche.data;
 
 import android.content.Context;
 import androidx.recyclerview.widget.RecyclerView;
+
+import android.os.Build;
+import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -69,7 +72,11 @@ public class ListAdapter extends RecyclerView.Adapter<ListAdapter.ViewHolder> {
         }
 
         public void bind(Article article) {
-            title.setText(article.getTitle());
+            if (Build.VERSION.SDK_INT >= 24) {
+                title.setText(Html.fromHtml(article.getTitle(), Html.FROM_HTML_MODE_LEGACY));
+            } else {
+                title.setText(Html.fromHtml(article.getTitle()));
+            }
             url.setText(article.getDomain());
 
             boolean showFavourite = false;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -14,6 +14,8 @@ import android.os.Build;
 import android.os.Bundle;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
+
+import android.text.Html;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -1225,7 +1227,11 @@ public class ReadArticleActivity extends BaseActionBarActivity {
 
         if(article == null) return false;
 
-        articleTitle = article.getTitle();
+        if (Build.VERSION.SDK_INT >= 24) {
+            articleTitle = Html.fromHtml(article.getTitle(), Html.FROM_HTML_MODE_LEGACY).toString();
+        } else {
+            articleTitle = Html.fromHtml(article.getTitle()).toString();
+        }
         Log.d(TAG, "loadArticle() articleTitle: " + articleTitle);
         articleDomain = article.getDomain();
         Log.d(TAG, "loadArticle() articleDomain: " + articleDomain);


### PR DESCRIPTION
Sometimes the title contains umlauts like äöüß or other special chars,
which are encoded as HTML. This commit decodes the HTML entities of the
title before displaying it in the article list or the read article view.

E.g. `ü` is displayed instead of `&uuml;`.