### PR TITLE
Extra error details

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -135,6 +135,9 @@
         <receiver
             android:name="fr.gaulupeau.apps.Poche.service.AlarmReceiver"
             android:enabled="false" />
+        <receiver
+            android:name="fr.gaulupeau.apps.Poche.service.NotificationActionReceiver"
+            android:exported="false"/>
 
         <service
             android:name="fr.gaulupeau.apps.Poche.service.WallabagJobService"

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/events/EventProcessor.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/events/EventProcessor.java
@@ -33,6 +33,7 @@ import fr.gaulupeau.apps.Poche.network.WallabagConnection;
 import fr.gaulupeau.apps.Poche.service.ActionRequest;
 import fr.gaulupeau.apps.Poche.service.ActionResult;
 import fr.gaulupeau.apps.Poche.service.AlarmHelper;
+import fr.gaulupeau.apps.Poche.service.NotificationActionReceiver;
 import fr.gaulupeau.apps.Poche.service.ServiceHelper;
 import fr.gaulupeau.apps.Poche.ui.IconUnreadWidget;
 import fr.gaulupeau.apps.Poche.ui.preferences.SettingsActivity;
@@ -540,6 +541,14 @@ public class EventProcessor {
                     if(!TextUtils.isEmpty(extra)) {
                         notificationBuilder.setStyle(new NotificationCompat.BigTextStyle()
                                 .bigText(context.getString(R.string.notification_expandedError, extra)));
+
+                        extra = detailedText + "\n" + extra;
+
+                        PendingIntent copyIntent = NotificationActionReceiver
+                                .getCopyToClipboardPendingIntent(context,
+                                        context.getString(R.string.notification_clipboardLabel), extra);
+                        notificationBuilder.addAction(0,
+                                context.getString(R.string.notification_copyToClipboard), copyIntent);
                     }
 
                     notification = notificationBuilder.build();

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/events/EventProcessor.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/events/EventProcessor.java
@@ -10,6 +10,8 @@ import android.os.Build;
 import android.os.Handler;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.FileProvider;
+
+import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.MimeTypeMap;
 import android.widget.Toast;
@@ -17,6 +19,8 @@ import android.widget.Toast;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Locale;
@@ -521,10 +525,21 @@ public class EventProcessor {
                                             : R.string.notification_error))
                                     .setContentText(detailedText);
 
-                    if(result.getMessage() != null) {
+                    String extra = "";
+                    if(!TextUtils.isEmpty(result.getMessage())) {
+                        extra += result.getMessage() + "\n";
+                    }
+                    if(result.getException() != null) {
+                        StringWriter sw = new StringWriter();
+
+                        sw.append(context.getString(R.string.notification_stacktrace)).append("\n");
+                        result.getException().printStackTrace(new PrintWriter(sw));
+
+                        extra += sw.toString();
+                    }
+                    if(!TextUtils.isEmpty(extra)) {
                         notificationBuilder.setStyle(new NotificationCompat.BigTextStyle()
-                                .bigText(context.getString(R.string.notification_expandedError,
-                                        result.getMessage())));
+                                .bigText(context.getString(R.string.notification_expandedError, extra)));
                     }
 
                     notification = notificationBuilder.build();

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/ActionResult.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/ActionResult.java
@@ -11,16 +11,26 @@ public class ActionResult {
     private boolean success = true;
     private ErrorType errorType;
     private String message;
+    private Exception exception;
 
     public ActionResult() {}
 
     public ActionResult(ErrorType errorType) {
-        setErrorType(errorType);
+        this(errorType, null, null);
     }
 
     public ActionResult(ErrorType errorType, String message) {
-        this(errorType);
+        this(errorType, message, null);
+    }
+
+    public ActionResult(ErrorType errorType, Exception exception) {
+        this(errorType, exception.toString(), exception);
+    }
+
+    public ActionResult(ErrorType errorType, String message, Exception exception) {
+        setErrorType(errorType);
         this.message = message;
+        this.exception = exception;
     }
 
     public boolean isSuccess() {
@@ -48,12 +58,21 @@ public class ActionResult {
         this.message = message;
     }
 
+    public Exception getException() {
+        return exception;
+    }
+
+    public void setException(Exception exception) {
+        this.exception = exception;
+    }
+
     void updateWith(ActionResult r) {
         if(r == null || r.isSuccess()) return;
 
         success = false;
         errorType = r.getErrorType();
         message = r.getMessage();
+        exception = r.getException();
     }
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/IntentServiceBase.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/IntentServiceBase.java
@@ -43,6 +43,7 @@ public abstract class IntentServiceBase extends IntentService {
                         ? ActionResult.ErrorType.SERVER_ERROR
                         : ActionResult.ErrorType.UNKNOWN);
                 result.setMessage(e.toString());
+                result.setException(e);
             }
         } else if(e instanceof IncorrectConfigurationException) {
             result.setErrorType(ActionResult.ErrorType.INCORRECT_CONFIGURATION);
@@ -72,6 +73,7 @@ public abstract class IntentServiceBase extends IntentService {
             if(!handled) {
                 result.setErrorType(ActionResult.ErrorType.UNKNOWN);
                 result.setMessage(e.toString());
+                result.setException(e);
             }
             // IOExceptions in most cases mean temporary error,
             // in some cases may mean that the action was completed anyway.
@@ -81,6 +83,7 @@ public abstract class IntentServiceBase extends IntentService {
         } else { // other exceptions meant to be handled outside
             result.setErrorType(ActionResult.ErrorType.UNKNOWN);
             result.setMessage(e.toString());
+            result.setException(e);
         }
 
         return result;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/MainService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/MainService.java
@@ -269,7 +269,7 @@ public class MainService extends IntentServiceBase {
             } catch(Exception e) {
                 Log.e(TAG, "syncOfflineQueue() item processing exception", e);
 
-                itemResult = new ActionResult(ActionResult.ErrorType.UNKNOWN, e.toString());
+                itemResult = new ActionResult(ActionResult.ErrorType.UNKNOWN, e);
             }
 
             if(itemResult != null && !itemResult.isSuccess() && canTolerateNotFound
@@ -440,6 +440,7 @@ public class MainService extends IntentServiceBase {
 
                 result.setErrorType(ActionResult.ErrorType.UNKNOWN);
                 result.setMessage(e.toString());
+                result.setException(e);
             }
         } else {
             result.setErrorType(ActionResult.ErrorType.NO_NETWORK);
@@ -478,6 +479,7 @@ public class MainService extends IntentServiceBase {
 
                 result.setErrorType(ActionResult.ErrorType.UNKNOWN);
                 result.setMessage(e.toString());
+                result.setException(e);
             }
         } else {
             result.setErrorType(ActionResult.ErrorType.NO_NETWORK);

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/NotificationActionReceiver.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/NotificationActionReceiver.java
@@ -1,0 +1,50 @@
+package fr.gaulupeau.apps.Poche.service;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import fr.gaulupeau.apps.InThePoche.R;
+
+public class NotificationActionReceiver extends BroadcastReceiver {
+
+    public static final String ACTION_COPY_TO_CLIPBOARD = "copy_to_clipboard";
+
+    public static final String EXTRA_COPY_TO_CLIPBOARD_LABEL = "copy_to_clipboard_label";
+    public static final String EXTRA_COPY_TO_CLIPBOARD_TEXT = "copy_to_clipboard_text";
+
+    public static PendingIntent getCopyToClipboardPendingIntent(
+            Context context, String label, String text) {
+        Intent intent = new Intent(context, NotificationActionReceiver.class);
+        intent.setAction(ACTION_COPY_TO_CLIPBOARD);
+        intent.putExtra(EXTRA_COPY_TO_CLIPBOARD_LABEL, label);
+        intent.putExtra(EXTRA_COPY_TO_CLIPBOARD_TEXT, text);
+
+        int code = ThreadLocalRandom.current().nextInt(); // so `PendingIntent` creates a **new** pending intent
+        return PendingIntent.getBroadcast(context, code, intent, 0);
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        if(ACTION_COPY_TO_CLIPBOARD.equals(action)) {
+            ClipboardManager clipboardManager = (ClipboardManager) context
+                    .getSystemService(Context.CLIPBOARD_SERVICE);
+
+            ClipData data = ClipData.newPlainText(
+                    intent.getStringExtra(EXTRA_COPY_TO_CLIPBOARD_LABEL),
+                    intent.getStringExtra(EXTRA_COPY_TO_CLIPBOARD_TEXT));
+
+            clipboardManager.setPrimaryClip(data);
+
+            Toast.makeText(context, context.getString(R.string.copiedToClipboard), Toast.LENGTH_SHORT).show();
+        }
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -320,4 +320,7 @@
     <string name="remove_tag">Remove tag</string>
 
     <string name="notification_stacktrace">Stacktrace:</string>
+    <string name="notification_copyToClipboard">Copy to clipboard</string>
+    <string name="notification_clipboardLabel">Error details</string>
+    <string name="copiedToClipboard">Copied to clipboard</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -318,4 +318,6 @@
     <string name="connectionWizard_summary_prev">Back</string>
     <string name="connectionWizard_summary_next">Save settings</string>
     <string name="remove_tag">Remove tag</string>
+
+    <string name="notification_stacktrace">Stacktrace:</string>
 </resources>


### PR DESCRIPTION
* Adds stacktrace to some error notifications.
* Adds a notification action to copy the details to clipboard.

The stacktrace information is not always useful, but it may help on a rare occasion (like in #668 it could help to at least determine which operation caused the error).