### PR TITLE
Improve link styling for high-contrast theme

### DIFF
--- a/app/src/main/assets/main.css
+++ b/app/src/main/assets/main.css
@@ -78,6 +78,11 @@ a:hover, a:focus {
   text-decoration: none;
 }
 
+.high-contrast a, a:hover, a:focus {
+  color: #000;
+  text-decoration: underline;
+}
+
 h2:after {
   content: "";
   height: 4px;


### PR DESCRIPTION
Looking at #84, the high-contrast theme originally was created for eReader
devices.

On my device (an Onyx Boox Nova Pro), it works quite well, but both links (being
a rather dark blue) and normal text get rendered as black, making it impossible
to tell them apart from normal text.

This change makes links black and re-adds the underlining.

cc @shtrom 