### PR TITLE
fix weblate issue "Found duplicated language: en (en, en)"

### DIFF
--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,1 +1,0 @@
-../values/strings.xml


### PR DESCRIPTION
This commit removes the symlink in app/src/main/res/:
values-en/strings.xml -> values/strings.xml

fixes #891