### PR TITLE
Update API wrapper

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,6 @@ dependencies {
     implementation 'com.facebook.stetho:stetho:1.5.1'
     implementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
     implementation 'com.mikepenz:aboutlibraries:7.1.0'
-    implementation 'com.github.di72nn.wallabag-api-wrapper:api-wrapper:v2.0.0-beta.2'
+    implementation 'com.github.di72nn.wallabag-api-wrapper:api-wrapper:v2.0.0-beta.3'
     implementation 'org.slf4j:slf4j-android:1.7.30'
 }


### PR DESCRIPTION
This only fixes article sweeping, which didn't do anything (apart from logging errors) since the last API wrapper update.

Also, releasing a beta/alpha of the app really wouldn't hurt.