### PR TITLE
Add basic options to dump and clean offline queue

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/StorageHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/StorageHelper.java
@@ -3,11 +3,16 @@ package fr.gaulupeau.apps.Poche.data;
 import androidx.core.content.ContextCompat;
 import android.util.Log;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 
 import fr.gaulupeau.apps.Poche.App;
 
@@ -112,6 +117,27 @@ public class StorageHelper {
 
     public static boolean deleteFile(String path) {
         return new File(path).delete();
+    }
+
+    public static File dumpQueueData(String data) throws IOException {
+        if (!isExternalStorageWritable()) {
+            throw new IllegalStateException("External storage is not writable!");
+        }
+
+        String path = getExternalStoragePath() + "/"
+                + "Local_changes_"
+                + new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(new Date())
+                + ".txt";
+        File file = new File(path);
+
+        //noinspection ResultOfMethodCallIgnored: should exist either way
+        file.createNewFile();
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+            writer.write(data);
+        }
+
+        return file;
     }
 
 }

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -71,6 +71,11 @@
     <string name="pref_key_misc_appendWallabagMention_enabled" translatable="false">misc.appendWallabagMention.enabled</string>
     <string name="pref_key_misc_handleHttpScheme" translatable="false">misc.handleHttpScheme</string>
     <string name="pref_key_misc_wipeDB" translatable="false">misc.wipeDB</string>
+    <string name="pref_key_misc_localQueue" translatable="false">misc.localQueue</string>
+    <string name="pref_key_misc_localQueue_category" translatable="false">misc.localQueue.category</string>
+    <string name="pref_key_misc_localQueue_notice" translatable="false">misc.localQueue.notice</string>
+    <string name="pref_key_misc_localQueue_dumpToFile" translatable="false">misc.localQueue.dumpToFile</string>
+    <string name="pref_key_misc_localQueue_removeFirstItem" translatable="false">misc.localQueue.removeFirstItem</string>
 
     <string name="pref_key_internal_preferencesVersion" translatable="false">internal.preferencesVersion</string>
     <string name="pref_key_internal_firstRun" translatable="false">internal.firstRun</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -281,6 +281,21 @@
     <string name="pref_desc_misc_wipeDB">Wipes all the articles from local database, also removes all not synchronized local changes and URLs</string>
     <string name="pref_name_misc_wipeDB_confirmTitle">Wipe Database?</string>
     <string name="pref_name_misc_wipeDB_confirmMessage">Are you sure you want to wipe the database?</string>
+    <string name="pref_categoryName_misc_localQueue">Local changes</string>
+    <string name="pref_name_misc_localQueue_notice">WARNING</string>
+    <string name="pref_desc_misc_localQueue_notice">Don\'t do anything here unless you know what you\'re doing</string>
+    <string name="pref_name_misc_localQueue_dumpToFile">Dump to file</string>
+    <string name="pref_desc_misc_localQueue_dumpToFile">Dumps all local changes to a txt file (you can study it yourself or attach it to a bug report)</string>
+    <string name="pref_name_misc_localQueue_removeFirstItem">Remove first local queue item</string>
+    <string name="pref_desc_misc_localQueue_removeFirstItem">Removes the first not synchronized item. May help if you get repeating error notifications during sync. Be sure to dump all local changes to file first</string>
+
+    <string name="misc_localQueue_empty">No local changes</string>
+    <string name="misc_localQueue_removeFirstItem_done">Done</string>
+    <string name="misc_localQueue_dumpToFile_result_dumped">Dumped to %s</string>
+    <string name="misc_localQueue_dumpToFile_result_error">Error: %s</string>
+    <string name="misc_localQueue_dumpToFile_header">If you experience troubles with synchronization, please report your problem here: %s</string>
+
+    <string name="issues_url" translatable="false">https://github.com/wallabag/android-app/issues</string>
 
     <string name="connectionWizard_misc_scanQrCode">Scan a QR code</string>
     <string name="connectionWizard_misc_installQrCodeScanner">Please install a QR-code scanner</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -269,6 +269,31 @@
                 android:title="@string/pref_name_misc_wipeDB"
                 android:summary="@string/pref_desc_misc_wipeDB"
                 android:persistent="false"/>
+            <PreferenceScreen
+                android:key="@string/pref_key_misc_localQueue"
+                android:persistent="false"
+                android:title="@string/pref_categoryName_misc_localQueue">
+                <PreferenceCategory
+                    android:key="@string/pref_key_misc_localQueue_category"
+                    android:persistent="false"
+                    android:title="@string/pref_categoryName_misc_localQueue">
+                    <Preference
+                        android:key="@string/pref_key_misc_localQueue_notice"
+                        android:persistent="false"
+                        android:summary="@string/pref_desc_misc_localQueue_notice"
+                        android:title="@string/pref_name_misc_localQueue_notice" />
+                    <Preference
+                        android:key="@string/pref_key_misc_localQueue_dumpToFile"
+                        android:persistent="false"
+                        android:summary="@string/pref_desc_misc_localQueue_dumpToFile"
+                        android:title="@string/pref_name_misc_localQueue_dumpToFile" />
+                    <Preference
+                        android:key="@string/pref_key_misc_localQueue_removeFirstItem"
+                        android:persistent="false"
+                        android:summary="@string/pref_desc_misc_localQueue_removeFirstItem"
+                        android:title="@string/pref_name_misc_localQueue_removeFirstItem" />
+                </PreferenceCategory>
+            </PreferenceScreen>
         </PreferenceCategory>
     </PreferenceScreen>
 </PreferenceScreen>


### PR DESCRIPTION
This adds `Settings -> Miscellaneous -> Local changes` submenu with two actions:
 * Dump to file.
   This saves the contents of the offline queue to a file to the app directory in the external storage.
 * Remove first local queue item.
   This, as the name suggests, removes the first local queue item. It should be enough because only the first item directly blocks synchronization. If there are more than one problem items, the action can be repeated.

This is a very basic improvement for #905 (and some other issues).

These options are not meant to be an obvious fix a user: the user should report the problem (so something may be fixed (like not saveable articles)) and be instructed to use these options to make the app usable again.