### PR TITLE
Add Gradle Wrapper Validation Action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 
 tasks {
     wrapper {
-        gradleVersion = "5.6"
+        gradleVersion = "5.6.4"
         distributionType = Wrapper.DistributionType.ALL
     }
 }


### PR DESCRIPTION
[Gradle Wrapper Validation Action](https://github.com/gradle/wrapper-validation-action).
This checks the committed `gradle-wrapper.jar` (but not the `gradlew` scripts?).
Not the same as [Verification of downloaded Gradle distributions](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification).

Also update gradle version in the wrapper task. Not sure if it is needed.