### PR TITLE
Don't use expired access token

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,6 @@ dependencies {
     implementation 'com.facebook.stetho:stetho:1.5.1'
     implementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
     implementation 'com.mikepenz:aboutlibraries:7.1.0'
-    implementation 'com.github.di72nn.wallabag-api-wrapper:api-wrapper:v2.0.0-beta.4'
+    implementation 'com.github.di72nn.wallabag-api-wrapper:api-wrapper:v2.0.0-beta.5'
     implementation 'org.slf4j:slf4j-android:1.7.30'
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -162,6 +162,14 @@ public class Settings {
         return contains(context.getString(keyResourceID));
     }
 
+    public void remove(String key) {
+        pref.edit().remove(key).apply();
+    }
+
+    public void remove(int keyResourceID) {
+        remove(context.getString(keyResourceID));
+    }
+
     public boolean getBoolean(String key, boolean defValue) {
         return pref.getBoolean(key, defValue);
     }
@@ -304,6 +312,20 @@ public class Settings {
 
     public void setApiAccessToken(String apiAccessToken) {
         setString(R.string.pref_key_connection_api_accessToken, apiAccessToken);
+    }
+
+    public Long getApiAccessTokenExpirationDate() {
+        return contains(R.string.pref_key_connection_api_accessTokenExpirationDate)
+                ? getLong(R.string.pref_key_connection_api_accessTokenExpirationDate, 0)
+                : null;
+    }
+
+    public void setApiAccessTokenExpirationDate(Long timestamp) {
+        if (timestamp == null) {
+            remove(R.string.pref_key_connection_api_accessTokenExpirationDate);
+        } else {
+            setLong(R.string.pref_key_connection_api_accessTokenExpirationDate, timestamp);
+        }
     }
 
     public String getHttpAuthUsername() {

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -11,6 +11,7 @@
     <string name="pref_key_connection_api_clientSecret" translatable="false">connection.api.clientSecret</string>
     <string name="pref_key_connection_api_refreshToken" translatable="false">connection.api.refreshToken</string>
     <string name="pref_key_connection_api_accessToken" translatable="false">connection.api.accessToken</string>
+    <string name="pref_key_connection_api_accessTokenExpirationDate" translatable="false">connection.api.accessTokenExpirationDate</string>
     <string name="pref_key_connection_advanced" translatable="false">connection.advanced</string>
     <string name="pref_key_connection_advanced_httpAuth_category" translatable="false">connection.advanced.httpAuth.category</string>
     <string name="pref_key_connection_advanced_httpAuthUsername" translatable="false">connection.advanced.httpAuthUsername</string>


### PR DESCRIPTION
API wrapper no longer tries to perform a request if no auth token is provided (until token refresh is performed). It also doesn't set auth headers on requests for endpoints that don't require them (like `version`).

The app now tracks token expiration date and doesn't use expired tokens.

That should solve the problem with fail2ban (https://github.com/YunoHost-Apps/wallabag2_ynh/issues/81) by properly fixing #789.