### PR TITLE
Avoid classloading warnings

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -26,9 +26,12 @@
 -keepclassmembers class * extends org.greenrobot.greendao.AbstractDao {
 public static java.lang.String TABLENAME;
 }
--keep class **$Properties
+-keep class **$Properties { *; }
 
-# If you do not use SQLCipher:
--dontwarn org.greenrobot.greendao.database.**
-# If you do not use Rx:
+# If you DO use SQLCipher:
+-keep class org.greenrobot.greendao.database.SqlCipherEncryptedHelper { *; }
+
+# If you do NOT use SQLCipher:
+-dontwarn net.sqlcipher.database.**
+# If you do NOT use RxJava:
 -dontwarn rx.**

--- a/app/src/main/java/net/sqlcipher/database/SQLiteDatabase.java
+++ b/app/src/main/java/net/sqlcipher/database/SQLiteDatabase.java
@@ -1,0 +1,13 @@
+package net.sqlcipher.database;
+
+import android.content.Context;
+
+/**
+ * Stub for https://github.com/greenrobot/greenDAO/issues/428.
+ * Remove after https://github.com/greenrobot/greenDAO/pull/924 is released.
+ */
+public class SQLiteDatabase {
+
+    public static void loadLibs(Context context) {}
+
+}

--- a/app/src/main/java/net/sqlcipher/database/SQLiteOpenHelper.java
+++ b/app/src/main/java/net/sqlcipher/database/SQLiteOpenHelper.java
@@ -1,0 +1,36 @@
+package net.sqlcipher.database;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase.CursorFactory;
+
+/**
+ * Stub for https://github.com/greenrobot/greenDAO/issues/428.
+ * Remove after https://github.com/greenrobot/greenDAO/pull/924 is released.
+ */
+public abstract class SQLiteOpenHelper {
+
+    public SQLiteOpenHelper(Context context, String name, CursorFactory factory, int version) {}
+
+    public abstract void onCreate(SQLiteDatabase db);
+
+    public abstract void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion);
+
+    public void onOpen(SQLiteDatabase db) {}
+
+    public SQLiteDatabase getReadableDatabase(String password) {
+        return null;
+    }
+
+    public SQLiteDatabase getReadableDatabase(char[] password) {
+        return null;
+    }
+
+    public SQLiteDatabase getWritableDatabase(String password) {
+        return null;
+    }
+
+    public SQLiteDatabase getWritableDatabase(char[] password) {
+        return null;
+    }
+
+}


### PR DESCRIPTION
Add a stub to avoid those lengthy warnings at startup:
```
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de: Rejecting re-init on previously-failed class java.lang.Class<org.greenrobot.greendao.database.DatabaseOpenHelper$EncryptedHelper>: java.lang.NoClassDefFoundError: Failed resolution of: Lnet/sqlcipher/database/SQLiteOpenHelper;
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.data.dao.DaoSession fr.gaulupeau.apps.Poche.data.DbConnection.getSession() (DbConnection.java:32)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.data.DbConnection$Holder.<clinit>() (DbConnection.java:60)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.data.dao.DaoSession fr.gaulupeau.apps.Poche.data.DbConnection$Holder.access$000() (DbConnection.java:59)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.data.dao.DaoSession fr.gaulupeau.apps.Poche.data.DbConnection.getSession() (DbConnection.java:22)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.data.dao.DaoSession fr.gaulupeau.apps.Poche.service.workers.BaseWorker.getDaoSession() (BaseWorker.java:35)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.service.ActionResult fr.gaulupeau.apps.Poche.service.workers.ArticleUpdateWorker.updateArticles(fr.gaulupeau.apps.Poche.service.ActionRequest) (ArticleUpdateWorker.java:76)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.service.ActionResult fr.gaulupeau.apps.Poche.service.workers.ArticleUpdateWorker.update(fr.gaulupeau.apps.Poche.service.ActionRequest) (ArticleUpdateWorker.java:37)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.service.ActionResult fr.gaulupeau.apps.Poche.service.tasks.UpdateArticlesTask.run(android.content.Context, fr.gaulupeau.apps.Poche.service.ActionRequest) (UpdateArticlesTask.java:17)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.tasks.ActionRequestTask.run(android.content.Context) (ActionRequestTask.java:25)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.-$$Lambda$Eg7UQkyPgCNRHvigqxzb-ridugA.run(android.content.Context) (lambda:-1)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.TaskService.run() (TaskService.java:158)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.TaskService.lambda$gjfracnqY8x0_-mrxsx0oqjQmgk(fr.gaulupeau.apps.Poche.service.TaskService) (TaskService.java:-1)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.-$$Lambda$TaskService$gjfracnqY8x0_-mrxsx0oqjQmgk.run() (lambda:-1)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void java.lang.Thread.run() (Thread.java:764)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de: Caused by: java.lang.ClassNotFoundException: Didn't find class "net.sqlcipher.database.SQLiteOpenHelper" on path: DexPathList[[zip file "/data/app/fr.gaulupeau.apps.InThePoche.dev-_glNYt-zjjoO4mFgG0mf0Q==/base.apk"],nativeLibraryDirectories=[/data/app/fr.gaulupeau.apps.InThePoche.dev-_glNYt-zjjoO4mFgG0mf0Q==/lib/arm64, /data/app/fr.gaulupeau.apps.InThePoche.dev-_glNYt-zjjoO4mFgG0mf0Q==/base.apk!/lib/arm64-v8a, /system/lib64, /vendor/lib64]]
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at java.lang.Class dalvik.system.BaseDexClassLoader.findClass(java.lang.String) (BaseDexClassLoader.java:134)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String, boolean) (ClassLoader.java:379)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at java.lang.Class java.lang.ClassLoader.loadClass(java.lang.String) (ClassLoader.java:312)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.data.dao.DaoSession fr.gaulupeau.apps.Poche.data.DbConnection.getSession() (DbConnection.java:32)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.data.DbConnection$Holder.<clinit>() (DbConnection.java:60)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.data.dao.DaoSession fr.gaulupeau.apps.Poche.data.DbConnection$Holder.access$000() (DbConnection.java:59)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.data.dao.DaoSession fr.gaulupeau.apps.Poche.data.DbConnection.getSession() (DbConnection.java:22)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.data.dao.DaoSession fr.gaulupeau.apps.Poche.service.workers.BaseWorker.getDaoSession() (BaseWorker.java:35)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.service.ActionResult fr.gaulupeau.apps.Poche.service.workers.ArticleUpdateWorker.updateArticles(fr.gaulupeau.apps.Poche.service.ActionRequest) (ArticleUpdateWorker.java:76)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.service.ActionResult fr.gaulupeau.apps.Poche.service.workers.ArticleUpdateWorker.update(fr.gaulupeau.apps.Poche.service.ActionRequest) (ArticleUpdateWorker.java:37)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at fr.gaulupeau.apps.Poche.service.ActionResult fr.gaulupeau.apps.Poche.service.tasks.UpdateArticlesTask.run(android.content.Context, fr.gaulupeau.apps.Poche.service.ActionRequest) (UpdateArticlesTask.java:17)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.tasks.ActionRequestTask.run(android.content.Context) (ActionRequestTask.java:25)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.-$$Lambda$Eg7UQkyPgCNRHvigqxzb-ridugA.run(android.content.Context) (lambda:-1)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.TaskService.run() (TaskService.java:158)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.TaskService.lambda$gjfracnqY8x0_-mrxsx0oqjQmgk(fr.gaulupeau.apps.Poche.service.TaskService) (TaskService.java:-1)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void fr.gaulupeau.apps.Poche.service.-$$Lambda$TaskService$gjfracnqY8x0_-mrxsx0oqjQmgk.run() (lambda:-1)
2020-04-25 12:48:56.669 29134-29243/fr.gaulupeau.apps.InThePoche.dev I/.InThePoche.de:     at void java.lang.Thread.run() (Thread.java:764)
...
```

The stubs can be removed after https://github.com/greenrobot/greenDAO/pull/924 is available.