### PR TITLE
Fix "add dialog" crash

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
@@ -931,8 +931,7 @@ public class MainActivity extends AppCompatActivity
 
         builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
             TextView textView = view.findViewById(R.id.page_url);
-            OperationsHelper.addArticleWithUI(getBaseContext(),
-                    textView.getText().toString(), null);
+            OperationsHelper.addArticleWithUI(this, textView.getText().toString(), null);
         });
         builder.setNegativeButton(android.R.string.cancel, null);
 


### PR DESCRIPTION
Test scenario: Main screen -> Add new entry -> OK.

Fixes the crash that's been reported in the "pre-launch report" and in the console:
```
06-20 10:23:54.413: E/AndroidRuntime(30523): FATAL EXCEPTION: Thread-2553
06-20 10:23:54.413: E/AndroidRuntime(30523): Process: fr.gaulupeau.apps.InThePoche, PID: 30523
06-20 10:23:54.413: E/AndroidRuntime(30523): android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
06-20 10:23:54.413: E/AndroidRuntime(30523): 	at android.app.ContextImpl.startActivity(ContextImpl.java:672)
06-20 10:23:54.413: E/AndroidRuntime(30523): 	at android.app.ContextImpl.startActivity(ContextImpl.java:659)
06-20 10:23:54.413: E/AndroidRuntime(30523): 	at fr.gaulupeau.apps.Poche.service.OperationsHelper.addArticleWithUI(OperationsHelper.java:39)
06-20 10:23:54.413: E/AndroidRuntime(30523): 	at fr.gaulupeau.apps.Poche.ui.MainActivity.lambda$showAddBagDialog$3$MainActivity(MainActivity.java:934)
06-20 10:23:54.413: E/AndroidRuntime(30523): 	at fr.gaulupeau.apps.Poche.ui.-$$Lambda$MainActivity$VI8v6PsPin0nTcg9cy19YmmIaEo.onClick(lambda)
06-20 10:23:54.413: E/AndroidRuntime(30523): 	at androidx.appcompat.app.AlertController$ButtonHandler.handleMessage(AlertController.java:167)
06-20 10:23:54.413: E/AndroidRuntime(30523): 	at android.os.Handler.dispatchMessage(Handler.java:102)
```