### PR TITLE
Add a splash screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,16 +19,23 @@
         android:theme="@style/LightTheme"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
+            android:name="fr.gaulupeau.apps.Poche.ui.SplashActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:theme="@style/SplashTheme">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name="fr.gaulupeau.apps.Poche.ui.MainActivity"
             android:theme="@style/LightTheme.NoActionBar">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <action android:name="android.intent.action.SEARCH"/>
-
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.SEARCH" />
             </intent-filter>
-            <meta-data android:name="android.app.searchable"
-                       android:resource="@xml/searchable"/>
+            <meta-data
+                android:name="android.app.searchable"
+                android:resource="@xml/searchable" />
         </activity>
         <activity
             android:name="fr.gaulupeau.apps.Poche.ui.ReadArticleActivity"

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/SplashActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/SplashActivity.java
@@ -1,0 +1,19 @@
+package fr.gaulupeau.apps.Poche.ui;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class SplashActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        startActivity(new Intent(this, MainActivity.class));
+        finish();
+    }
+
+}

--- a/app/src/main/res/drawable/background_splash.xml
+++ b/app/src/main/res/drawable/background_splash.xml
@@ -1,0 +1,8 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/splash_background"/>
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/welcome_white"/>
+    </item>
+</layer-list>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -19,4 +19,5 @@
     <color name="darkContrastBlack">#000000</color>
     <color name="darkContrastWhite">#FFFFFF</color>
     <color name="darkContrastGray">#9c9c9c</color>
+    <color name="splash_background">#222</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -187,4 +187,10 @@
         <item name="android:windowIsFloating">true</item>
         <item name="android:backgroundDimEnabled">false</item>
     </style>
+
+    <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
+        <item name="colorPrimary">@color/splash_background</item>
+        <item name="colorPrimaryDark">@android:color/transparent</item>
+        <item name="android:windowBackground">@drawable/background_splash</item>
+    </style>
 </resources>


### PR DESCRIPTION
That white startup screen is starting to get to me.

I don't think startup time is going to be improved anytime soon, so here's a splash screen.

To the best of my knowledge it cannot be made light or dark according to in-app theme (because splash screen theme is applied before any app code is executed). So I made it dark, because a dark screen is okay in light environment, but a light screen is annoying in the dark.