### PR TITLE
Fix IndexOutOfBoundsException in ManageArticleTagsActivity

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ManageArticleTagsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ManageArticleTagsActivity.java
@@ -457,7 +457,7 @@ public class ManageArticleTagsActivity extends BaseActionBarActivity {
         out.clear();
 
         if (TextUtils.isEmpty(filterLabel) && excludeList.isEmpty() || src.isEmpty()) {
-            out.addAll(limit >= 0 ? src.subList(0, limit) : src);
+            out.addAll(limit >= 0 ? src.subList(0, Math.min(limit, src.size())) : src);
             return out;
         }
 


### PR DESCRIPTION
...when there are less than 50 tags in total.

A crash from google console:
```
java.lang.IndexOutOfBoundsException:
  at java.util.ArrayList.subListRangeCheck (ArrayList.java:1016)
  at java.util.ArrayList.subList (ArrayList.java:1008)
  at fr.gaulupeau.apps.Poche.ui.ManageArticleTagsActivity.filterTagList (ManageArticleTagsActivity.java:460)
  at fr.gaulupeau.apps.Poche.ui.ManageArticleTagsActivity.updateSuggestedTagList (ManageArticleTagsActivity.java:309)
  at fr.gaulupeau.apps.Poche.ui.ManageArticleTagsActivity.textChanged (ManageArticleTagsActivity.java:305)
  at fr.gaulupeau.apps.Poche.ui.ManageArticleTagsActivity.access$000 (ManageArticleTagsActivity.java:51)
  at fr.gaulupeau.apps.Poche.ui.ManageArticleTagsActivity$1.afterTextChanged (ManageArticleTagsActivity.java:118)
  at android.widget.TextView.sendAfterTextChanged (TextView.java:10973)
  at android.widget.TextView.setText (TextView.java:6376)
  at android.widget.TextView.setText (TextView.java:6170)
  at android.widget.EditText.setText (EditText.java:146)
  at android.widget.TextView.setText (TextView.java:6127)
  at fr.gaulupeau.apps.Poche.ui.ManageArticleTagsActivity.setEditText (ManageArticleTagsActivity.java:429)
  at fr.gaulupeau.apps.Poche.ui.ManageArticleTagsActivity.onCreate (ManageArticleTagsActivity.java:148)
  at android.app.Activity.performCreate (Activity.java:7326)
  at android.app.Activity.performCreate (Activity.java:7317)
  at android.app.Instrumentation.callActivityOnCreate (Instrumentation.java:1271)
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:3072)
```

Shame on me.