### PR TITLE
Fix annotations

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/CallableParameterizedAdapter.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/CallableParameterizedAdapter.java
@@ -1,0 +1,18 @@
+package fr.gaulupeau.apps.Poche.service;
+
+import java.util.concurrent.Callable;
+
+class CallableParameterizedAdapter<V> extends ParameterizedAdapter implements Callable<V> {
+
+    protected final ParameterizedCallable<V> parameterizedCallable;
+
+    public CallableParameterizedAdapter(ParameterizedCallable<V> parameterizedCallable) {
+        this.parameterizedCallable = parameterizedCallable;
+    }
+
+    @Override
+    public V call() throws Exception {
+        return parameterizedCallable.call(context);
+    }
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/OperationsHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/OperationsHelper.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.util.Log;
 
 import java.util.List;
+import java.util.concurrent.Future;
 
 import fr.gaulupeau.apps.Poche.data.DbConnection;
 import fr.gaulupeau.apps.Poche.data.DbUtils;
@@ -26,6 +27,7 @@ import wallabag.apiwrapper.WallabagService;
 import static fr.gaulupeau.apps.Poche.service.ServiceHelper.enqueueServiceTask;
 import static fr.gaulupeau.apps.Poche.service.ServiceHelper.enqueueSimpleServiceTask;
 import static fr.gaulupeau.apps.Poche.service.ServiceHelper.startService;
+import static fr.gaulupeau.apps.Poche.service.ServiceHelper.submitServiceCallableTask;
 
 public class OperationsHelper {
 
@@ -73,8 +75,8 @@ public class OperationsHelper {
                 .setArticleTags(article, newTags), postCallCallback);
     }
 
-    public static void addAnnotation(Context context, int articleId, Annotation annotation) {
-        enqueueServiceTask(context, ctx -> new OperationsWorker(ctx)
+    public static Future<Annotation> addAnnotation(Context context, int articleId, Annotation annotation) {
+        return submitServiceCallableTask(context, ctx -> new OperationsWorker(ctx)
                 .addAnnotation(articleId, annotation), null);
     }
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/Parameterized.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/Parameterized.java
@@ -1,0 +1,7 @@
+package fr.gaulupeau.apps.Poche.service;
+
+import android.content.Context;
+
+interface Parameterized {
+    void setContext(Context context);
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/ParameterizedAdapter.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/ParameterizedAdapter.java
@@ -1,0 +1,14 @@
+package fr.gaulupeau.apps.Poche.service;
+
+import android.content.Context;
+
+abstract class ParameterizedAdapter implements Parameterized {
+
+    protected Context context;
+
+    @Override
+    public void setContext(Context context) {
+        this.context = context;
+    }
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/ParameterizedCallable.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/ParameterizedCallable.java
@@ -1,0 +1,7 @@
+package fr.gaulupeau.apps.Poche.service;
+
+import android.content.Context;
+
+public interface ParameterizedCallable<V> {
+    V call(Context context) throws Exception;
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/ParameterizedRunnable.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/ParameterizedRunnable.java
@@ -1,0 +1,7 @@
+package fr.gaulupeau.apps.Poche.service;
+
+import android.content.Context;
+
+public interface ParameterizedRunnable {
+    void run(Context context);
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/ParameterizedRunnableAdapter.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/ParameterizedRunnableAdapter.java
@@ -1,0 +1,27 @@
+package fr.gaulupeau.apps.Poche.service;
+
+import android.content.Context;
+
+import java.util.Objects;
+
+class ParameterizedRunnableAdapter implements ParameterizedRunnable {
+
+    protected Runnable runnable;
+    protected Parameterized parameterized;
+
+    public ParameterizedRunnableAdapter(Runnable runnable, Parameterized parameterized) {
+        this.runnable = Objects.requireNonNull(runnable);
+        this.parameterized = parameterized;
+    }
+
+    @Override
+    public void run(Context context) {
+        try {
+            if (parameterized != null) parameterized.setContext(context);
+            runnable.run();
+        } finally {
+            if (parameterized != null) parameterized.setContext(null);
+        }
+    }
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/RunnableParameterizedAdapter.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/RunnableParameterizedAdapter.java
@@ -1,0 +1,16 @@
+package fr.gaulupeau.apps.Poche.service;
+
+class RunnableParameterizedAdapter extends ParameterizedAdapter implements Runnable {
+
+    protected final ParameterizedRunnable parameterizedRunnable;
+
+    public RunnableParameterizedAdapter(ParameterizedRunnable parameterizedRunnable) {
+        this.parameterizedRunnable = parameterizedRunnable;
+    }
+
+    @Override
+    public void run() {
+        parameterizedRunnable.run(context);
+    }
+
+}

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/OperationsWorker.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/OperationsWorker.java
@@ -400,7 +400,7 @@ public class OperationsWorker extends BaseWorker {
         Log.d(TAG, "setArticleTagsInternal() finished");
     }
 
-    public void addAnnotation(int articleId, Annotation annotation) {
+    public Annotation addAnnotation(int articleId, Annotation annotation) {
         Log.d(TAG, String.format("addAnnotation(%d, %s) started", articleId, annotation));
 
         Article article = getArticle(articleId);
@@ -441,6 +441,7 @@ public class OperationsWorker extends BaseWorker {
         }
 
         Log.d(TAG, "addAnnotation() finished");
+        return annotation;
     }
 
     public void updateAnnotation(int articleId, Annotation annotation) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/OperationsWorker.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/OperationsWorker.java
@@ -455,9 +455,7 @@ public class OperationsWorker extends BaseWorker {
 
         String newText = annotation.getText();
 
-        AnnotationDao annotationDao = getDaoSession().getAnnotationDao();
-        annotation = annotationDao.queryBuilder()
-                .where(AnnotationDao.Properties.Id.eq(annotationId)).unique();
+        annotation = getAnnotation(annotationId);
 
         if (TextUtils.equals(annotation.getText(), newText)) {
             Log.w(TAG, "updateAnnotation() annotation ID=" + annotationId
@@ -467,7 +465,7 @@ public class OperationsWorker extends BaseWorker {
 
         annotation.setText(newText);
 
-        annotationDao.update(annotation);
+        getDaoSession().getAnnotationDao().update(annotation);
         Log.d(TAG, "updateAnnotation() annotation object updated");
 
         Article article = getArticle(articleId);
@@ -484,6 +482,8 @@ public class OperationsWorker extends BaseWorker {
 
     public void deleteAnnotation(int articleId, Annotation annotation) {
         Log.d(TAG, String.format("deleteAnnotation(%d, %s) started", articleId, annotation));
+
+        annotation = getAnnotation(annotation.getId());
 
         Integer remoteId = annotation.getAnnotationId();
 
@@ -512,6 +512,11 @@ public class OperationsWorker extends BaseWorker {
         }
 
         Log.d(TAG, "deleteAnnotation() finished");
+    }
+
+    private Annotation getAnnotation(long annotationId) {
+        return getDaoSession().getAnnotationDao().queryBuilder()
+                .where(AnnotationDao.Properties.Id.eq(annotationId)).unique();
     }
 
     private Article getArticle(int articleId) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.Future;
 
 import fr.gaulupeau.apps.InThePoche.BuildConfig;
 import fr.gaulupeau.apps.InThePoche.R;
@@ -798,10 +799,9 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                     }
 
                     @Override
-                    public Annotation createAnnotation(Annotation annotation) {
-                        OperationsHelper.addAnnotation(ReadArticleActivity.this,
-                                article.getArticleId(), annotation);
-                        return annotation;
+                    public Annotation createAnnotation(Annotation annotation) { // TODO: fix: waiting call
+                        return waitForFuture(OperationsHelper.addAnnotation(
+                                ReadArticleActivity.this, article.getArticleId(), annotation));
                     }
 
                     @Override
@@ -816,6 +816,15 @@ public class ReadArticleActivity extends BaseActionBarActivity {
                         OperationsHelper.deleteAnnotation(ReadArticleActivity.this,
                                 article.getArticleId(), annotation);
                         return annotation;
+                    }
+
+                    private <T> T waitForFuture(Future<T> future) {
+                        try {
+                            return future.get();
+                        } catch (Exception e) {
+                            Log.w("JsAnnotCtrl.Callback", "waitForFuture() exception", e);
+                        }
+                        return null;
                     }
                 });
 


### PR DESCRIPTION
Turns out annotations got broken when I switched to async `TaskService`: adding an annotation is supposed to be a synchronous operation. That is fixed with introduction of [`Future`](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Future.html) support in `TaskService`/`ServiceHelper` (may be useful for other stuff in the future).

Annotation deletion seems to have been broken from the very beginning. I don't know how I missed that.

Fixes #1026.