### PR TITLE
Foreground services

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/MainService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/MainService.java
@@ -1,9 +1,32 @@
 package fr.gaulupeau.apps.Poche.service;
 
+import android.app.Notification;
+
+import androidx.core.app.NotificationCompat;
+
+import fr.gaulupeau.apps.InThePoche.R;
+import fr.gaulupeau.apps.Poche.ui.NotificationsHelper;
+
 public class MainService extends TaskService {
 
     public MainService() {
         super(MainService.class.getSimpleName());
+    }
+
+    @Override
+    protected int getForegroundNotificationId() {
+        return 100;
+    }
+
+    @Override
+    protected Notification getForegroundNotification() {
+        NotificationsHelper.initNotificationChannels();
+
+        return new NotificationCompat.Builder(
+                this, NotificationsHelper.CHANNEL_ID_BACKGROUND_OPERATIONS)
+                .setSmallIcon(R.drawable.ic_action_refresh)
+                .setContentTitle(getString(R.string.notification_backgroundOperations))
+                .build();
     }
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/SecondaryService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/SecondaryService.java
@@ -1,9 +1,32 @@
 package fr.gaulupeau.apps.Poche.service;
 
+import android.app.Notification;
+
+import androidx.core.app.NotificationCompat;
+
+import fr.gaulupeau.apps.InThePoche.R;
+import fr.gaulupeau.apps.Poche.ui.NotificationsHelper;
+
 public class SecondaryService extends TaskService {
 
     public SecondaryService() {
         super(SecondaryService.class.getSimpleName());
+    }
+
+    @Override
+    protected int getForegroundNotificationId() {
+        return 101;
+    }
+
+    @Override
+    protected Notification getForegroundNotification() {
+        NotificationsHelper.initNotificationChannels();
+
+        return new NotificationCompat.Builder(
+                this, NotificationsHelper.CHANNEL_ID_BACKGROUND_OPERATIONS)
+                .setSmallIcon(R.drawable.ic_action_refresh)
+                .setContentTitle(getString(R.string.notification_backgroundOperations))
+                .build();
     }
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/ServiceHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/ServiceHelper.java
@@ -8,6 +8,7 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
 import androidx.core.util.Consumer;
 
 import java.util.concurrent.Future;
@@ -67,7 +68,8 @@ public class ServiceHelper {
     public static void enqueueSimpleServiceTask(Context context,
                                                 Class<? extends TaskService> serviceClass,
                                                 SimpleTask task) {
-        context.startService(TaskService.newSimpleTaskIntent(context, serviceClass, task));
+        ContextCompat.startForegroundService(
+                context, TaskService.newSimpleTaskIntent(context, serviceClass, task));
     }
 
     public static void enqueueServiceTask(Context context, ParameterizedRunnable task,

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/ServiceHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/ServiceHelper.java
@@ -68,8 +68,15 @@ public class ServiceHelper {
     public static void enqueueSimpleServiceTask(Context context,
                                                 Class<? extends TaskService> serviceClass,
                                                 SimpleTask task) {
-        ContextCompat.startForegroundService(
-                context, TaskService.newSimpleTaskIntent(context, serviceClass, task));
+        Intent intent = TaskService.newSimpleTaskIntent(context, serviceClass, task);
+        try {
+            context.startService(intent);
+        } catch (IllegalStateException e) {
+            Log.w(TAG, "enqueueSimpleServiceTask() failed to start normal service", e);
+
+            intent.putExtra(TaskService.PARAM_FOREGROUND, true);
+            ContextCompat.startForegroundService(context, intent);
+        }
     }
 
     public static void enqueueServiceTask(Context context, ParameterizedRunnable task,

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/TaskService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/TaskService.java
@@ -1,10 +1,12 @@
 package fr.gaulupeau.apps.Poche.service;
 
 import android.annotation.SuppressLint;
+import android.app.Notification;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import android.os.Process;
 import android.util.Log;
@@ -19,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import fr.gaulupeau.apps.Poche.service.tasks.SimpleTask;
 
 @SuppressLint("Registered") // subclassed
-public class TaskService extends Service {
+public abstract class TaskService extends Service {
 
     public static final String ACTION_SIMPLE_TASK = "action_simple_task";
 
@@ -92,6 +94,8 @@ public class TaskService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(tag, "onStartCommand()");
+
+        setForeground(true);
 
         if (ACTION_SIMPLE_TASK.equals(intent.getAction())) {
             ParameterizedRunnable task = taskFromSimpleTask(SimpleTask.fromIntent(intent));
@@ -174,6 +178,8 @@ public class TaskService extends Service {
     private void readyToStop() {
         Log.d(tag, "readyToStop()");
 
+        setForeground(false);
+
         if (!stopSelfResult(lastStartId)) {
             Log.d(tag, "readyToStop() startId didn't match");
         }
@@ -198,5 +204,21 @@ public class TaskService extends Service {
 
         startService(newStartIntent(this, getClass()));
     }
+
+    private void setForeground(boolean foreground) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return; // normal services are good enough before Oreo
+        }
+
+        if (foreground) {
+            startForeground(getForegroundNotificationId(), getForegroundNotification());
+        } else {
+            stopForeground(true);
+        }
+    }
+
+    protected abstract int getForegroundNotificationId();
+
+    protected abstract Notification getForegroundNotification();
 
 }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/TaskService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/TaskService.java
@@ -25,6 +25,8 @@ public abstract class TaskService extends Service {
 
     public static final String ACTION_SIMPLE_TASK = "action_simple_task";
 
+    public static final String PARAM_FOREGROUND = "param_foreground";
+
     public class TaskServiceBinder extends Binder {
         public void enqueue(ParameterizedRunnable parameterizedRunnable) {
             TaskService.this.enqueueTask(parameterizedRunnable, true);
@@ -95,7 +97,9 @@ public abstract class TaskService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(tag, "onStartCommand()");
 
-        setForeground(true);
+        if (intent.getBooleanExtra(PARAM_FOREGROUND, false)) {
+            setForeground(true);
+        }
 
         if (ACTION_SIMPLE_TASK.equals(intent.getAction())) {
             ParameterizedRunnable task = taskFromSimpleTask(SimpleTask.fromIntent(intent));

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/NotificationsHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/NotificationsHelper.java
@@ -22,6 +22,7 @@ public class NotificationsHelper {
     public static final String CHANNEL_ID_TTS = "fr.gaulupeau.apps.Poche.tts";
     public static final String CHANNEL_ID_SYNC = "sync";
     public static final String CHANNEL_ID_DOWNLOADING_ARTICLES = "downloading_articles";
+    public static final String CHANNEL_ID_BACKGROUND_OPERATIONS = "background_operations";
     public static final String CHANNEL_ID_ERRORS = "errors";
 
     private static boolean notificationChannelsInitialized;
@@ -81,6 +82,13 @@ public class NotificationsHelper {
                     NotificationManager.IMPORTANCE_LOW
             );
             channel.setGroup(channelGroupSync.getId());
+            channels.add(channel);
+
+            channel = new NotificationChannel(
+                    CHANNEL_ID_BACKGROUND_OPERATIONS, context.getString(R.string.notification_channel_name_background_operations),
+                    NotificationManager.IMPORTANCE_LOW
+            );
+            channel.setGroup(channelGroupOther.getId());
             channels.add(channel);
 
             channel = new NotificationChannel(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,7 @@
     <string name="notification_sweepingDeletedArticles">Sweeping deleted articles</string>
     <string name="notification_downloadingImages">Downloading images</string>
     <string name="notification_syncingQueue">Synchronizing local changes</string>
+    <string name="notification_backgroundOperations">Background operations</string>
     <string name="notification_error">Error</string>
     <string name="notification_incorrectCredentials">Incorrect credentials</string>
     <string name="notification_incorrectConfiguration">Incorrect configuration</string>
@@ -133,6 +134,7 @@
     <string name="notification_channel_name_tts">wallabag TTS</string>
     <string name="notification_channel_name_sync">Synchronization</string>
     <string name="notification_channel_name_downloading_articles">Downloading PDFs</string>
+    <string name="notification_channel_name_background_operations">Background operations</string>
     <string name="notification_channel_name_error">Errors</string>
     <string name="menu_lists_search">Search</string>
     <string name="menu_lists_changeSortOrder">Change sort order</string>


### PR DESCRIPTION
I'm not sure if I'll be able to properly deal with #974 anytime soon, so here's a not so elegant but simple fix.

This PR should fix a whole slew of `IllegalStateException`s reported in the Play Console. Fixes #975, #784.

Using foreground services has some merit for some of the tasks, but #974 still stands.

First commit here makes the app use foreground services for any background tasks. This is technically ok, but Android requires to display a visible notification when the service is running, which is quite annoying (especially because in this implementation the notifications don't have any meaningful content). These notifications may be disabled (using notification channels), but *only manually by the user*.

According to Play Console the errors are relatively rare, so the app should work fine with non-foreground services *most of the time*. The second commit tries to use foreground services only when starting a normal service fails. This is debatable.

The simplest way to test it is to enable autosync on app start, and start the app with the screen turned off (like with `adb shell am start -n fr.gaulupeau.apps.InThePoche.debug/fr.gaulupeau.apps.Poche.ui.MainActivity` or directly from AndroidStudio). There's a timeout in `MainActivity.updateOnStartup()` though.