### PR TITLE
Update target sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
   components:
     - tools
     - build-tools-29.0.2
-    - android-28
+    - android-29
     - extra-android-m2repository
   licenses:
     - ".+"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.greenrobot.greendao'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "fr.gaulupeau.apps.InThePoche"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 226
         versionName "2.4.0"
 

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -7,7 +7,9 @@
     </issue>
 
     <!-- Consider localization issues as Warnings -->
-    <issue id="MissingTranslation" severity="warning" />
     <issue id="MissingQuantity" severity="warning" />
     <issue id="ExtraTranslation" severity="warning" />
+
+    <!-- Not helpful-->
+    <issue id="MissingTranslation" severity="ignore" />
 </lint>

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleActionsHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleActionsHelper.java
@@ -2,6 +2,7 @@ package fr.gaulupeau.apps.Poche.ui;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
@@ -171,26 +172,24 @@ public class ArticleActionsHelper {
 
         boolean errorMessage = false;
 
-        if (intent.resolveActivity(context.getPackageManager()) != null) {
-            try {
-                context.startActivity(intent);
-            } catch (RuntimeException e) {
-                boolean rethrow = true;
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    if (e instanceof FileUriExposedException) {
-                        // apparently happens when user clicks on some file URI in an article
-                        Log.w(TAG, "openUrl()", e);
-                        errorMessage = true;
-                        rethrow = false;
-                    }
-                }
-
-                if (rethrow) throw e;
-            }
-        } else {
+        try {
+            context.startActivity(intent);
+        } catch (ActivityNotFoundException e) {
             Log.w(TAG, "openUrl() no activity to handle intent");
             errorMessage = true;
+        } catch (RuntimeException e) {
+            boolean rethrow = true;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                if (e instanceof FileUriExposedException) {
+                    // apparently happens when user clicks on some file URI in an article
+                    Log.w(TAG, "openUrl()", e);
+                    errorMessage = true;
+                    rethrow = false;
+                }
+            }
+
+            if (rethrow) throw e;
         }
 
         if (errorMessage) {

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -15,7 +15,6 @@
     <string name="ttsFastForward">Rychle vpřed</string>
     <string name="notification_action_media_play">Spustit</string>
     <string name="notification_action_media_rewind">Posunout zpět</string>
-    <string name="unsuccessfulRequest_errorMessage">Neúspěšný požadavek; kód odezvy: %1$d, zpráva odezvy: %2$s</string>
     <string name="d_testConnection_urlSuggestion_declineButton">Použít moji</string>
     <string name="d_testConnection_urlSuggestion_acceptButton">Použít doporučenou</string>
     <string name="d_testConnection_urlSuggestion_title">Zvažte změnu URL adresy</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -50,7 +50,6 @@
     <string name="testConnection_errorMessage_unknownWithMessage">Unbekannter Fehler: %s</string>
     <string name="d_testConnection_fail_title">Verbindungstest fehlgeschlagen</string>
     <string name="wrongUsernameOrPassword_errorMessage">Anmeldung nicht möglich: Vermutlich falscher Benutzername oder Passwort</string>
-    <string name="unsuccessfulRequest_errorMessage">"Anfrage nicht erfolgreich; Antwortcode: %1$d, Antwortnachricht: %2$s"</string>
     <string name="previousUpdateNotFinished">Vorherige Aktualisierung noch nicht fertig</string>
     <string name="feedName_favorites">Favoriten</string>
     <string name="feedName_archived">Archiviert</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -81,7 +81,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">Error desconocido</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">Error desconocido: %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">Inicio de sesión fallido: Probablemente usuario o contraseña incorrecta</string>
-    <string name="unsuccessfulRequest_errorMessage">"Solicitud fallida; código de respuesta: %1$d, mensaje de respuesta: %2$s"</string>
     <string name="previousUpdateNotFinished">La actualización anterior aún no ha terminado</string>
     <string name="feedName_favorites">Favoritos</string>
     <string name="feedName_archived">Archivados</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -79,7 +79,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">Errore ezezaguna</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">Errore ezezaguna: %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">Ezin izan da saioa hasi: Ziur aski erabiltzaile-izen edo pasahitz okerra</string>
-    <string name="unsuccessfulRequest_errorMessage">Eskaera ez da burutu; erantzun-kodea: %1$d, erantzun-mezua: %2$s</string>
     <string name="previousUpdateNotFinished">Aurreko eguneratzea oraindik ez da amaitu</string>
     <string name="feedName_favorites">Gogokoak</string>
     <string name="feedName_archived">Artxibatuak</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -83,7 +83,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">Erreur inconnue</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">Erreur inconnue : %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">Impossible de se connecter : L\'identifiant et le mot de passe doivent être erronés</string>
-    <string name="unsuccessfulRequest_errorMessage">"Échec de la requête. Code de réponse : %1$d. Message de réponse : %2$s"</string>
     <string name="previousUpdateNotFinished">La mise à jour précédente n\'est pas terminée</string>
     <string name="feedName_favorites">Favoris</string>
     <string name="feedName_archived">Archivés</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -57,7 +57,6 @@
     <string name="noPreviousArticle">Nema prethodnog članka u trenutačnom popisu</string>
     <string name="d_checkCredentials_errorMessage_unknown">Nepoznata greška</string>
     <string name="connectionWizard_welcome_prev">Preskoči</string>
-    <string name="unsuccessfulRequest_errorMessage">Zahtjev neuspješan; kod odgovora: %1$d, poruka odgovora: %2$s</string>
     <string name="downloadAsFilePathStart">Preuzimanje članka</string>
     <string name="d_getCredentials_title_fail">Neuspjelo dobivanje podataka za prijavu na sučelje</string>
     <string name="d_testConnection_fail_title">Provjera veze neuspjela</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -69,7 +69,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">Ismeretlen hiba</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">Ismeretlen hiba: %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">Nem lehetett bejelentkezni: feltételezhetően rossz a felhasználónév vagy a jelszó</string>
-    <string name="unsuccessfulRequest_errorMessage">Kérés sikertelen; válasz kód: %1$d, válasz üzenet: %2$s</string>
     <string name="previousUpdateNotFinished">Az előző frissítés még nem fejeződött be</string>
     <string name="feedName_favorites">Kedvencek</string>
     <string name="feedName_archived">Archívum</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -79,7 +79,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">Errore sconosciuto</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">Errore sconosciuto: %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">Accesso impossibile: eventuali nome utente o password sbagliati</string>
-    <string name="unsuccessfulRequest_errorMessage">"Richiesta senza successo; codice di risposta: %1$d, messaggio di risposta: %2$s"</string>
     <string name="previousUpdateNotFinished">Aggiornamento precedente non ancora completato</string>
     <string name="feedName_favorites">Preferiti</string>
     <string name="feedName_archived">Archiviati</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -67,7 +67,6 @@
     <string name="d_testConnection_urlSuggestion_message_mandatory">URL を変更することをお勧めします: %s</string>
     <string name="d_testConnection_fail_title">接続テストに失敗しました</string>
     <string name="wrongUsernameOrPassword_errorMessage">ログインできませんでした: おそらくユーザー名またはパスワードが間違っています</string>
-    <string name="unsuccessfulRequest_errorMessage">要求が失敗しました。レスポンスコード: %1$d、レスポンスメッセージ: %2$s</string>
     <string name="previousUpdateNotFinished">以前の更新がまだ終わっていません</string>
     <string name="feedName_favorites">お気に入り</string>
     <string name="feedName_archived">アーカイブ済</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -164,7 +164,6 @@
     <string name="downloadAsFileArticleDownloadedDetail">기사가 %s 다운로드되었다</string>
     <string name="connectionWizard_summary_next">설정 저장</string>
     <string name="downloadAsFileTouchToOpen">열려면 터치</string>
-    <string name="unsuccessfulRequest_errorMessage">요청 실패, 응답 코드: %1$d, 응답 메시지: %2$s</string>
     <string name="dialog_add_label">새로운 기사 추가</string>
     <string name="connectionWizard_provider_wallabagit_prev">이전</string>
     <string name="menuOpenOriginal">원문 열기</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -151,7 +151,6 @@
     <string name="pref_name_sync_syncTypes">Synkroniseringstyper</string>
     <string name="pref_desc_sync_syncTypes">Trykk for å vise mer info om synkroniseringstyper</string>
     <string name="wrongUsernameOrPassword_errorMessage">Kunne ikke logge inn: Antagelig galt brukernavn eller passord</string>
-    <string name="unsuccessfulRequest_errorMessage">Forespørsel mislykket; svarkode: %1$d, svarmelding: %2$s</string>
     <string name="previousUpdateNotFinished">Forrige oppdatering er ikke ferdig</string>
     <string name="articleList_favoriteMark">Favorittmarkering</string>
     <string name="articleList_ArchivedMark">Arkiveringsmerking</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -72,7 +72,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">Onbekende fout</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">Onbekende fout: %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">Kon niet inloggen: Waarschijnlijk een incorrecte gebruikersnaam of wachtwoord</string>
-    <string name="unsuccessfulRequest_errorMessage">Verzoek onsuccesvol; antwoord code: %1$d, antwoord bericht: %2$s</string>
     <string name="previousUpdateNotFinished">Vorige update is nog niet klaar</string>
     <string name="feedName_favorites">Favorieten</string>
     <string name="feedName_archived">Opgeslagen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -79,7 +79,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">Nieznany błądr</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">Nieznany błąd: %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">Nie można się zalogować: Prawdopodobnie niewłaściwa nazwa użytkownika lub hasło</string>
-    <string name="unsuccessfulRequest_errorMessage">"Nieudane żądanie; kod odpowiedzi: %1$d, treść odpowiedzi: %2$s"</string>
     <string name="previousUpdateNotFinished">Poprzednia aktualizacja nie została jeszcze zakończona</string>
     <string name="feedName_favorites">Ulubione</string>
     <string name="feedName_archived">Zarchiwizowane</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -37,7 +37,6 @@
     <string name="testConnection_errorMessage_unknownWithMessage">Неизвестная ошибка: %s</string>
     <string name="d_testConnection_fail_title">Ошибка</string>
     <string name="wrongUsernameOrPassword_errorMessage">Ошибка входа: предположительно, неверное имя пользователя или пароль</string>
-    <string name="unsuccessfulRequest_errorMessage">"Запрос отклонён; код ответа: %1$d, сообщение: %2$s"</string>
     <string name="previousUpdateNotFinished">Предыдущее обновление ещё не завершилось</string>
     <string name="feedName_favorites">Избранное</string>
     <string name="feedName_archived">Архив</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -79,7 +79,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">Bilinmeyen hata</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">Bilinmeyen hata: %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">Giriş yapılamadı: Tahminen hatalı kullanıcı adı veya parola</string>
-    <string name="unsuccessfulRequest_errorMessage">Başarısız istek; yanıt kodu: %1$d, yanıt iletisi: %2$s</string>
     <string name="previousUpdateNotFinished">Bir önceki güncelleme işlemi henüz bitmedi</string>
     <string name="feedName_favorites">Favoriler</string>
     <string name="feedName_archived">Arşiv</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -83,7 +83,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">未知错误</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">未知错误: %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">无法登录: 可能是错误的用户名或密码</string>
-    <string name="unsuccessfulRequest_errorMessage">请求失败；响应代码: %1$d，响应消息: %2$s</string>
     <string name="previousUpdateNotFinished">上一个更新尚未完成</string>
     <string name="feedName_favorites">收藏</string>
     <string name="feedName_archived">存档</string>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,15 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="toppadding">10px</dimen>
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="nav_header_vertical_spacing">16dp</dimen>
     <dimen name="nav_header_height">160dp</dimen>
-
-    <!--
-Refer to App Widget Documentation for margin information
-http://developer.android.com/guide/topics/appwidgets/index.html#CreatingLayout
-    -->
-    <dimen name="widget_margin">8dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,7 +83,6 @@
     <string name="d_checkCredentials_errorMessage_unknown">Unknown error</string>
     <string name="d_checkCredentials_errorMessage_unknownWithMessage">Unknown error: %s</string>
     <string name="wrongUsernameOrPassword_errorMessage">Couldn\'t log in: Presumably wrong username or password</string>
-    <string name="unsuccessfulRequest_errorMessage">"Request unsuccessful; response code: %1$d, response message: %2$s"</string>
     <string name="previousUpdateNotFinished">Previous update not finished yet</string>
     <string name="feedName_favorites">Favorites</string>
     <string name="feedName_archived">Archived</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+    <base-config
+        cleartextTrafficPermitted="true"
+        tools:ignore="InsecureBaseConfiguration">
         <trust-anchors>
-            <certificates src="system"/>
-            <certificates src="user"/>
+            <certificates src="system" />
+            <certificates
+                src="user"
+                tools:ignore="AcceptsUserCertificates" />
         </trust-anchors>
     </base-config>
 </network-security-config>


### PR DESCRIPTION
I read through Android 10 changes and it seems that targeting it should not break things. I also checked 8 & 9 and didn't find anything we haven't already addressed.

The lint-related commits are not required for the target SDK change, but they make lint report less horrendous (and checking the report is important for the change).

I tested this PR on Android 11 emulator.
It also works fine with #1068 included.

Fixes #1024, fixes #644.