### PR TITLE
Full-text-search: add an option to use ICU tokenizer

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -690,6 +690,14 @@ public class Settings {
         setBoolean(R.string.pref_key_misc_appendWallabagMention_enabled, value);
     }
 
+    public boolean isFtsIcuTokenizerEnabled() {
+        return getBoolean(R.string.pref_key_misc_ftsIcuTokenizer_enabled, false);
+    }
+
+    public void setFtsIcuTokenizerEnabled(boolean value) {
+        setBoolean(R.string.pref_key_misc_ftsIcuTokenizer_enabled, value);
+    }
+
     public boolean isFirstRun() {
         return getBoolean(R.string.pref_key_internal_firstRun, true);
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/FtsDao.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/dao/FtsDao.java
@@ -4,6 +4,8 @@ import android.os.Build;
 
 import org.greenrobot.greendao.database.Database;
 
+import fr.gaulupeau.apps.Poche.App;
+
 public class FtsDao {
 
     public static final String TABLE_NAME = "article_fts";
@@ -53,7 +55,8 @@ public class FtsDao {
     private static void createTable(Database db, boolean ifNotExists) {
         String options = ", content=\"" + VIEW_FOR_FTS_NAME + "\"";
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            options += ", tokenize=unicode61";
+            options += ", tokenize="
+                    + (App.getSettings().isFtsIcuTokenizerEnabled() ? "icu" : "unicode61");
         }
 
         db.execSQL("create virtual table " + getIfNotExistsConstraint(ifNotExists) +

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.app.AlarmManager;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.EditTextPreference;
@@ -172,6 +173,14 @@ public class SettingsActivity extends BaseActionBarActivity {
             if (handleHttpSchemePreference != null) {
                 handleHttpSchemePreference.setChecked(settings.isHandlingHttpScheme());
                 handleHttpSchemePreference.setOnPreferenceChangeListener(this);
+            }
+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                CheckBoxPreference ftsIcuTokenizerPreference = (CheckBoxPreference) findPreference(
+                        getString(R.string.pref_key_misc_ftsIcuTokenizer_enabled));
+                if (ftsIcuTokenizerPreference != null) {
+                    ftsIcuTokenizerPreference.setEnabled(false);
+                }
             }
 
             ListPreference dbPathListPreference = (ListPreference)findPreference(

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -80,6 +80,7 @@
     <string name="pref_key_misc_category" translatable="false">misc.category</string>
     <string name="pref_key_misc_appendWallabagMention_enabled" translatable="false">misc.appendWallabagMention.enabled</string>
     <string name="pref_key_misc_handleHttpScheme" translatable="false">misc.handleHttpScheme</string>
+    <string name="pref_key_misc_ftsIcuTokenizer_enabled" translatable="false">misc.ftsIcuTokenizer.enabled</string>
     <string name="pref_key_misc_wipeDB" translatable="false">misc.wipeDB</string>
     <string name="pref_key_misc_localQueue" translatable="false">misc.localQueue</string>
     <string name="pref_key_misc_localQueue_category" translatable="false">misc.localQueue.category</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -296,6 +296,8 @@
     <string name="pref_desc_misc_appendWallabagMention">Append \"via @wallabagapp\" to shared texts</string>
     <string name="pref_name_misc_handleHttpScheme">Handle HTTP scheme</string>
     <string name="pref_desc_misc_handleHttpScheme">Show wallabag in the list of web browsers</string>
+    <string name="pref_name_misc_ftsIcuTokenizer_enabled">Use ICU tokenizer for full-text-search</string>
+    <string name="pref_desc_misc_ftsIcuTokenizer_enabled">Uses ICU tokenizer for full-text-search indexing (generic unicode61 tokenizer is used otherwise). May improve search results for CJK languages. \"Full update\" is required for the option to take effect</string>
     <string name="pref_name_misc_wipeDB">Wipe Database</string>
     <string name="pref_desc_misc_wipeDB">Wipes all the articles from local database, also removes all not synchronized local changes and URLs</string>
     <string name="pref_name_misc_wipeDB_confirmTitle">Wipe Database?</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -306,6 +306,11 @@
                 android:summary="@string/pref_desc_misc_handleHttpScheme"
                 android:defaultValue="false"
                 android:persistent="false"/>
+            <CheckBoxPreference
+                android:key="@string/pref_key_misc_ftsIcuTokenizer_enabled"
+                android:title="@string/pref_name_misc_ftsIcuTokenizer_enabled"
+                android:summary="@string/pref_desc_misc_ftsIcuTokenizer_enabled"
+                android:defaultValue="false"/>
             <ListPreference
                 android:key="@string/pref_key_storage_dbPath"
                 android:title="@string/pref_name_storage_dbPath"


### PR DESCRIPTION
Probably fixes #1090.

The currently used FTS tokenizer (`unicode61`) doesn't know anything about CJK, so it doesn't split words in these languages.
I'm not sure about the quality, but the [`icu`](http://site.icu-project.org/home) tokenizer seems to do a better job at this (to my understanding `unicode61` is still better for latin-based languages, hence it is the default).

Here are some tests I ran on an emulator (Android 8.1):
```SQL
adb shell
sqlite3

CREATE VIRTUAL TABLE ft3_tokenize_test_unicode USING fts3tokenize(unicode61);
CREATE VIRTUAL TABLE ft3_tokenize_test_icu USING fts3tokenize(icu);
CREATE VIRTUAL TABLE ft3_tokenize_test_icu_cn_simplified USING fts3tokenize(icu, zh_CN);
CREATE VIRTUAL TABLE ft3_tokenize_test_icu_cn_traditional USING fts3tokenize(icu, zh_TW);

SELECT token, start, end, position FROM ft3_tokenize_test_unicode WHERE input='为什么不支持中文 fts test';
SELECT token, start, end, position FROM ft3_tokenize_test_icu WHERE input='为什么不支持中文 fts test';
SELECT token, start, end, position FROM ft3_tokenize_test_icu_cn_simplified WHERE input='为什么不支持中文 fts test';
SELECT token, start, end, position FROM ft3_tokenize_test_icu_cn_traditional WHERE input='为什么不支持中文 fts test';

SELECT token, start, end, position FROM ft3_tokenize_test_unicode WHERE input='据台湾中时新闻网报道，一份最新民调今天（24日）出炉 fts test 2';
SELECT token, start, end, position FROM ft3_tokenize_test_icu WHERE input='据台湾中时新闻网报道，一份最新民调今天（24日）出炉 fts test 2';
SELECT token, start, end, position FROM ft3_tokenize_test_icu_cn_simplified WHERE input='据台湾中时新闻网报道，一份最新民调今天（24日）出炉 fts test 2';
SELECT token, start, end, position FROM ft3_tokenize_test_icu_cn_traditional WHERE input='据台湾中时新闻网报道，一份最新民调今天（24日）出炉 fts test 2';
```
`icu`, `icu zh_CN` and `icu zh_TW` produced the same result in this case.

I also tried to find [this article](https://news.sina.com.cn/c/2020-10-25/doc-iiznctkc7491922.shtml) using this query: `据台湾`.