### PR TITLE
Ignore Conscrypt initialization error

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagConnection.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/network/WallabagConnection.java
@@ -31,6 +31,8 @@ import wallabag.apiwrapper.models.TokenResponse;
 
 public class WallabagConnection {
 
+    private static final String TAG = WallabagConnection.class.getSimpleName();
+
     private static boolean conscryptInitialized;
 
     private static WallabagService wallabagService;
@@ -42,7 +44,11 @@ public class WallabagConnection {
         synchronized (WallabagConnection.class) {
             if (conscryptInitialized) return;
 
-            Security.insertProviderAt(Conscrypt.newProvider(), 1);
+            try {
+                Security.insertProviderAt(Conscrypt.newProvider(), 1);
+            } catch (Throwable t) {
+                Log.w(TAG, "initConscrypt() error", t);
+            }
 
             conscryptInitialized = true;
         }


### PR DESCRIPTION
That's not an absolute necessity to use it.

Modern Androids seems to use a Conscrypt-based stack on system level anyway.

Fixes #1091.