### PR TITLE
Lower max query length of the `exists` API request

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/DeletedArticleSweeper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/DeletedArticleSweeper.java
@@ -189,7 +189,7 @@ public class DeletedArticleSweeper extends BaseNetworkWorker {
 
                 if (existQueryBuilder == null) {
                     existQueryBuilder = wallabagService
-                            .getArticlesExistQueryBuilder(7950);
+                            .getArticlesExistQueryBuilder();
                 }
 
                 if (existQueryBuilder.addUrl(url)) {


### PR DESCRIPTION
...to avoid StreamResetException with HTTP2+nginx.

Use the library default instead of a custom value.

Fixes #909.

This is the value used to limit query length in the requests used in the "deleted articles sweeping" procedure.

The currently used max of 7950 fits about 132 URLs (in the new hashed form). I don't remember where that came from.
I was considering using something around 5k (fits ~83), but that's not reliable, because it was found out empirically.
For reasons I don't remember I chose 3990 (fits ~66) as the default value in the library. I don't feel like investigating it now and I think I can trust my past self with this choice.

Anyway, I don't think halving the number of URLs in a request will have any noticeable impact either on UX or server load.