### PR TITLE
Use creation date instead of article ID for sorting

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/ArticleImagesFetcher.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/ArticleImagesFetcher.java
@@ -66,7 +66,7 @@ public class ArticleImagesFetcher extends BaseNetworkWorker {
         QueryBuilder<Article> queryBuilder = articleDao.queryBuilder()
                 .where(ArticleDao.Properties.ArticleId.isNotNull())
                 .where(ArticleDao.Properties.ImagesDownloaded.eq(false))
-                .orderAsc(ArticleDao.Properties.ArticleId);
+                .orderAsc(ArticleDao.Properties.CreationDate, ArticleDao.Properties.ArticleId);
 
         int totalNumber = (int) queryBuilder.count();
         Log.d(TAG, "fetchImages() total number: " + totalNumber);

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/DeletedArticleSweeper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/service/workers/DeletedArticleSweeper.java
@@ -145,7 +145,8 @@ public class DeletedArticleSweeper extends BaseNetworkWorker {
 
         QueryBuilder<Article> queryBuilder = articleDao.queryBuilder()
                 .where(ArticleDao.Properties.ArticleId.isNotNull())
-                .orderDesc(ArticleDao.Properties.ArticleId).limit(dbQuerySize);
+                .orderDesc(ArticleDao.Properties.CreationDate, ArticleDao.Properties.ArticleId)
+                .limit(dbQuerySize);
 
         List<Long> articlesToDelete = new ArrayList<>();
 

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ArticleListFragment.java
@@ -236,11 +236,11 @@ public class ArticleListFragment extends RecyclerViewListFragment<Article, ListA
 
         switch (sortOrder) {
             case ASC:
-                qb.orderAsc(ArticleDao.Properties.ArticleId);
+                qb.orderAsc(ArticleDao.Properties.CreationDate, ArticleDao.Properties.ArticleId);
                 break;
 
             case DESC:
-                qb.orderDesc(ArticleDao.Properties.ArticleId);
+                qb.orderDesc(ArticleDao.Properties.CreationDate, ArticleDao.Properties.ArticleId);
                 break;
 
             default:

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -1340,14 +1340,15 @@ public class ReadArticleActivity extends BaseActionBarActivity {
         QueryBuilder<Article> qb = articleDao.queryBuilder()
                 .where(ArticleDao.Properties.ArticleId.isNotNull());
 
-        if (previous) qb.where(ArticleDao.Properties.ArticleId.gt(article.getArticleId()));
-        else qb.where(ArticleDao.Properties.ArticleId.lt(article.getArticleId()));
+        // possible problem: will skip articles with the same creation date
+        if (previous) qb.where(ArticleDao.Properties.CreationDate.gt(article.getCreationDate()));
+        else qb.where(ArticleDao.Properties.CreationDate.lt(article.getCreationDate()));
 
         if (contextFavorites != null) qb.where(ArticleDao.Properties.Favorite.eq(contextFavorites));
         if (contextArchived != null) qb.where(ArticleDao.Properties.Archive.eq(contextArchived));
 
-        if (previous) qb.orderAsc(ArticleDao.Properties.ArticleId);
-        else qb.orderDesc(ArticleDao.Properties.ArticleId);
+        if (previous) qb.orderAsc(ArticleDao.Properties.CreationDate);
+        else qb.orderDesc(ArticleDao.Properties.CreationDate);
 
         List<Article> l = qb.limit(1).list();
         if (!l.isEmpty()) {


### PR DESCRIPTION
I'll need to benchmark it, probably add an index.

Either I miss something or it's impossible to get "previous/next article" using SQL if creation dates may be duplicate **and** grow in a different direction from IDs. It is possible to select multiple articles and choose one on the Java side, but I don't think it's worth it.