### PR TITLE
Make the "Scan a QR code" button less pronounced

### DIFF
--- a/app/src/main/res/layout/connection_wizard_provider_selection_fragment.xml
+++ b/app/src/main/res/layout/connection_wizard_provider_selection_fragment.xml
@@ -54,11 +54,19 @@
                     android:text="@string/connectionWizard_providerSelection_provider_general_desc" />
             </RadioGroup>
 
-            <Button
-                android:id="@+id/scanQrCodeButton"
-                android:layout_gravity="center"
+            <TextView
+                android:layout_marginTop="30dp"
+                android:textAlignment="center"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:text="@string/connectionWizard_misc_scanQrCode_desc" />
+
+            <Button
+                android:id="@+id/scanQrCodeButton"
+                style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:drawableStart="@drawable/ic_qrcode_24dp"
                 android:text="@string/connectionWizard_misc_scanQrCode" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,6 +329,8 @@
     <string name="issues_url" translatable="false">https://github.com/wallabag/android-app/issues</string>
 
     <string name="connectionWizard_misc_scanQrCode">Scan a QR code</string>
+    <string name="connectionWizard_misc_scanQrCode_desc">Or configure the app using a QR code\n
+        (available in the \"Config\" section of the web application)</string>
     <string name="connectionWizard_misc_installQrCodeScanner">(Install a QR-code scanner first.)</string>
     <string name="connectionWizard_misc_incorrectConnectionURI">Incorrect connection URI used</string>
 


### PR DESCRIPTION
I often click the "Scan a QR code" button instead of "Next" when I configure the app for tests. I think the button should be toned down a little, so it is not assumed to be the default action.


Current | This PR
--- | ---
![Screenshot_1641716546](https://user-images.githubusercontent.com/1114779/148675653-776c1587-6015-450a-933a-f484465170c2.png) | ![Screenshot_1641717449](https://user-images.githubusercontent.com/1114779/148675660-b7a3fd42-514c-4f2a-967a-09a4600e31d5.png)

Here are two alternatives I tried first:
1 | 2
--- | ---
![Screenshot_1641717164](https://user-images.githubusercontent.com/1114779/148675689-904eb193-ffce-4bfe-9021-685a079ae2b7.png) | ![Screenshot_1641717227](https://user-images.githubusercontent.com/1114779/148675697-5eae34c8-27f5-4aa1-9dcd-3ee4cafc7bab.png)

I don't have any artistic vision - any suggestions are welcome :)