### PR TITLE
Allow the user to select their SD card and other external storage paths in addition to emulated SD storage

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/StorageHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/StorageHelper.java
@@ -56,32 +56,15 @@ public class StorageHelper {
         }
     }
 
-    private static String getFirstExternalStoragePath() {
-        File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(App.getInstance(), null);
-        for (File extStorageDir : externalFilesDirs) {
-            if (extStorageDir == null) {
-                continue;
-            }
-
-            return extStorageDir.getPath();
-        }
-        return null;
-    }
-
     public static String getExternalStoragePath() {
         String storagePathSetting = App.getSettings().getDbPath();
 
-        if ("external".equals(storagePathSetting)) {
-            File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(App.getInstance(), null);
-            for (File extStorageDir : externalFilesDirs) {
-                if (extStorageDir == null) {
-                    continue;
-                }
-
-                return extStorageDir.getPath();
-            }
+        if (!TextUtils.isEmpty(storagePathSetting)) {
+            return storagePathSetting;
         }
-        return storagePathSetting;
+
+        List<String> externalStoragePaths = getExternalStoragePaths();
+        return !externalStoragePaths.isEmpty() ? externalStoragePaths.get(0) : null;
     }
 
     public static List<String> getExternalStoragePaths() {
@@ -102,10 +85,7 @@ public class StorageHelper {
     }
 
     public static boolean isExternalStorageReadable() {
-        String storagePath = App.getSettings().getDbPath();
-        if (TextUtils.isEmpty(storagePath)) {
-            storagePath = getFirstExternalStoragePath();
-        }
+        String storagePath = getExternalStoragePath();
         if (storagePath == null) return false;
 
         File f = new File(storagePath);
@@ -113,11 +93,7 @@ public class StorageHelper {
     }
 
     public static boolean isExternalStorageWritable() {
-        String storagePath = App.getSettings().getDbPath();
-        if (TextUtils.isEmpty(storagePath)) {
-            storagePath = getFirstExternalStoragePath();
-        }
-        return isPathWritable(storagePath);
+        return isPathWritable(getExternalStoragePath());
     }
 
     private static boolean isPathWritable(String path) {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/StorageHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/StorageHelper.java
@@ -1,6 +1,7 @@
 package fr.gaulupeau.apps.Poche.data;
 
 import android.content.res.Resources;
+import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.core.content.ContextCompat;
@@ -15,7 +16,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.channels.FileChannel;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 
 import fr.gaulupeau.apps.Poche.App;
@@ -28,8 +31,6 @@ public class StorageHelper {
     }
 
     private static final String TAG = StorageHelper.class.getSimpleName();
-
-    private static String externalStoragePath;
 
     public static String readRawString(int id) {
         try {
@@ -55,42 +56,74 @@ public class StorageHelper {
         }
     }
 
+    private static String getFirstExternalStoragePath() {
+        File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(App.getInstance(), null);
+        for (File extStorageDir : externalFilesDirs) {
+            if (extStorageDir == null) {
+                continue;
+            }
+
+            return extStorageDir.getPath();
+        }
+        return null;
+    }
+
     public static String getExternalStoragePath() {
-        if(externalStoragePath == null) {
-            String returnPath = null;
+        String storagePathSetting = App.getSettings().getDbPath();
+
+        if ("external".equals(storagePathSetting)) {
             File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(App.getInstance(), null);
-            // TODO: better SD Card detection
-            for(File extStorageDir: externalFilesDirs) {
-                if(extStorageDir == null) {
-                    Log.w(TAG, "getExternalStoragePath() extStorageDir is null");
+            for (File extStorageDir : externalFilesDirs) {
+                if (extStorageDir == null) {
                     continue;
                 }
 
-                returnPath = extStorageDir.getPath();
-                Log.d(TAG, "getExternalStoragePath() extStorageDir.getPath(): " + returnPath);
-                break;
+                return extStorageDir.getPath();
+            }
+        }
+        return storagePathSetting;
+    }
+
+    public static List<String> getExternalStoragePaths() {
+        List<String> usableExternalFilesDirs = new ArrayList<>();
+
+        for (File extStorageDir : ContextCompat.getExternalFilesDirs(App.getInstance(), null)) {
+            if (extStorageDir == null) {
+                Log.w(TAG, "getExternalStoragePaths() extStorageDir is null");
+                continue;
             }
 
-            Log.d(TAG, "getExternalStoragePath() returnPath: " + returnPath);
-            return externalStoragePath = returnPath;
+            usableExternalFilesDirs.add(extStorageDir.getPath());
+            Log.d(TAG, "getExternalStoragePaths() extStorageDir.getPath(): "
+                    + extStorageDir.getPath());
         }
 
-        return externalStoragePath;
+        return usableExternalFilesDirs;
     }
 
     public static boolean isExternalStorageReadable() {
-        String externalStoragePath = getExternalStoragePath();
-        if(externalStoragePath == null) return false;
+        String storagePath = App.getSettings().getDbPath();
+        if (TextUtils.isEmpty(storagePath)) {
+            storagePath = getFirstExternalStoragePath();
+        }
+        if (storagePath == null) return false;
 
-        File f = new File(externalStoragePath);
+        File f = new File(storagePath);
         return f.exists() && f.canRead();
     }
 
     public static boolean isExternalStorageWritable() {
-        String externalStoragePath = getExternalStoragePath();
-        if(externalStoragePath == null) return false;
+        String storagePath = App.getSettings().getDbPath();
+        if (TextUtils.isEmpty(storagePath)) {
+            storagePath = getFirstExternalStoragePath();
+        }
+        return isPathWritable(storagePath);
+    }
 
-        File f = new File(externalStoragePath);
+    private static boolean isPathWritable(String path) {
+        if (path == null) return false;
+
+        File f = new File(path);
         return f.exists() && f.canWrite();
     }
 
@@ -144,11 +177,12 @@ public class StorageHelper {
     }
 
     public static File dumpQueueData(String data) throws IOException {
-        if (!isExternalStorageWritable()) {
+        String externalStoragePath = getExternalStoragePath();
+        if (!isPathWritable(externalStoragePath)) {
             throw new IllegalStateException("External storage is not writable!");
         }
 
-        String path = getExternalStoragePath() + "/"
+        String path = externalStoragePath + "/"
                 + "Local_changes_"
                 + new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(new Date())
                 + ".txt";

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/StorageHelper.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/StorageHelper.java
@@ -67,7 +67,7 @@ public class StorageHelper {
         return !externalStoragePaths.isEmpty() ? externalStoragePaths.get(0) : null;
     }
 
-    public static List<String> getExternalStoragePaths() {
+    private static List<String> getExternalStoragePaths() {
         List<String> usableExternalFilesDirs = new ArrayList<>();
 
         for (File extStorageDir : ContextCompat.getExternalFilesDirs(App.getInstance(), null)) {
@@ -82,6 +82,16 @@ public class StorageHelper {
         }
 
         return usableExternalFilesDirs;
+    }
+
+    public static List<String> getWritableExternalStoragePaths() {
+        List<String> paths = new ArrayList<>();
+        for (String path : getExternalStoragePaths()) {
+            if (isPathWritable(path)) {
+                paths.add(path);
+            }
+        }
+        return paths;
     }
 
     public static boolean isExternalStorageReadable() {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -183,11 +183,9 @@ public class SettingsActivity extends BaseActionBarActivity {
                 entriesList.add(getString(R.string.pref_name_storage_dbPath_internalStorage));
                 entryValuesList.add("");
 
-                if (StorageHelper.isExternalStorageWritable()) {
-                    for (String path : StorageHelper.getExternalStoragePaths()) {
-                        entriesList.add(getString(R.string.pref_name_storage_dbPath_externalStorage, path));
-                        entryValuesList.add(path);
-                    }
+                for (String path : StorageHelper.getWritableExternalStoragePaths()) {
+                    entriesList.add(getString(R.string.pref_name_storage_dbPath_externalStorage, path));
+                    entryValuesList.add(path);
                 }
 
                 dbPathListPreference.setEntries(entriesList.toArray(new String[0]));

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -183,9 +183,11 @@ public class SettingsActivity extends BaseActionBarActivity {
                 entriesList.add(getString(R.string.pref_name_storage_dbPath_internalStorage));
                 entryValuesList.add("");
 
-                if(StorageHelper.isExternalStorageWritable()) {
-                    entriesList.add(getString(R.string.pref_name_storage_dbPath_externalStorage));
-                    entryValuesList.add(StorageHelper.getExternalStoragePath());
+                if (StorageHelper.isExternalStorageWritable()) {
+                    for (String path : StorageHelper.getExternalStoragePaths()) {
+                        entriesList.add(getString(R.string.pref_name_storage_dbPath_externalStorage, path));
+                        entryValuesList.add(path);
+                    }
                 }
 
                 dbPathListPreference.setEntries(entriesList.toArray(new String[0]));
@@ -733,10 +735,9 @@ public class SettingsActivity extends BaseActionBarActivity {
                         CharSequence value = dbPathListPreference.getEntry();
                         if(TextUtils.isEmpty(value)) {
                             dbPathListPreference.setSummary(R.string.pref_name_storage_dbPath_internalStorage);
-                        } else if(value.equals(StorageHelper.getExternalStoragePath())) {
-                            dbPathListPreference.setSummary(R.string.pref_name_storage_dbPath_externalStorage);
                         } else {
-                            dbPathListPreference.setSummary(value);
+                            dbPathListPreference.setSummary(
+                                    getString(R.string.pref_name_storage_dbPath_externalStorage, value));
                         }
                     }
                     break;

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -89,7 +89,7 @@
     <string name="pref_desc_imageCache_enabled">Descarregar automàticament totes les imatges de cada article al dispositiu (ocupa molt de temps i espai si la llista d\'articles és llarga)</string>
     <string name="pref_name_storage_dbPath">Ubicació de la base de dades</string>
     <string name="pref_name_storage_dbPath_internalStorage">Emmagatzematge intern</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Emmagatzematge extern</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Emmagatzematge extern: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">Base de dades reubicada</string>
     <string name="pref_categoryName_miscellaneous">Divers</string>
     <string name="pref_name_misc_addTitleToSharedText">Afegir títol al text compartit</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -186,7 +186,7 @@
     <string name="d_urlAction_title">Vyberte akci pro adresu URL</string>
     <string name="menu_syncLocalChanges">Synchronizovat místní změny</string>
     <string name="pref_name_storage_dbPath_internalStorage">Interní úložiště</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Externí úložiště</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Externí úložiště: %s</string>
     <string name="settings_parametersAutofilled">Parametry vyplněny</string>
     <string name="nav_add">Přidat novou položku</string>
     <string name="navigation_drawer_close">Zavřít navigační panel</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -264,7 +264,7 @@
     <string name="pref_desc_ui_disableTouch_keyCode">Drücke hier, um die Taste für De-/Aktivierung von Toucheingaben zu wählen</string>
     <string name="pref_name_storage_dbPath">Datenbankspeicherort</string>
     <string name="pref_name_storage_dbPath_internalStorage">Interner Speicher</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Externer Speicher</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Externer Speicher: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">Datenbank verschoben</string>
     <string name="pref_name_misc_appendWallabagMention">Hänge wallabag Erwähnung an</string>
     <string name="pref_desc_misc_appendWallabagMention">Hänge „via @wallabagapp“ an geteilte Text an</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -84,7 +84,7 @@
     <string name="pref_name_misc_appendWallabagMention">Προσθήκη αναφοράς wallabag</string>
     <string name="pref_categoryName_miscellaneous">Ποικίλα</string>
     <string name="pref_name_storage_dbPath_dbMoved">Η βάση δεδομένων μετακινήθηκε</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Εξωτερικός αποθηκευτικός χώρος</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Εξωτερικός αποθηκευτικός χώρος: %s</string>
     <string name="pref_name_storage_dbPath_internalStorage">Εσωτερικός αποθηκευτικός χώρος</string>
     <string name="pref_name_storage_dbPath">Τοποθεσία βάσης δεδομένων</string>
     <string name="pref_desc_autoSync_enabled">Συγχρονίζει τοπικές αλλαγές (προσθήκη συνδέσμων, αρχειοθετημένα άρθρα, κλπ.) αυτόματα και κατεβάζει καινούρια άρθρα σύμφωνα με το πρόγραμμα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -219,7 +219,7 @@
     <string name="pref_desc_imageCache_enabled">Descarga automáticamente todas las imágenes de cada artículo y las guarda en el dispositivo (tarda bastante tiempo y consume bastante espacio si la lista de artículos es larga)</string>
     <string name="pref_name_storage_dbPath">Ubicación de la base de datos</string>
     <string name="pref_name_storage_dbPath_internalStorage">Almacenamiento interno</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Almacenamiento externo</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Almacenamiento externo: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">Base de datos reubicada</string>
     <string name="pref_categoryName_miscellaneous">Misceláneos</string>
     <string name="pref_name_misc_appendWallabagMention">Añadir mención a wallabag</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -118,7 +118,7 @@
     <string name="pref_name_misc_appendWallabagMention">افزودن اشاره به والابگ</string>
     <string name="pref_categoryName_miscellaneous">متفرقه</string>
     <string name="pref_name_storage_dbPath_dbMoved">پایگاه داده منتقل شد</string>
-    <string name="pref_name_storage_dbPath_externalStorage">حافظه خارجی</string>
+    <string name="pref_name_storage_dbPath_externalStorage">حافظه خارجی: %s</string>
     <string name="pref_name_storage_dbPath_internalStorage">حافظه داخلی</string>
     <string name="pref_name_storage_dbPath">مکان پایگاه داده</string>
     <string name="pref_name_imageCache_enabled">قرار دادن تصاویر مقاله در حافظه نهان</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -234,7 +234,7 @@
     <string name="pref_desc_imageCache_enabled">Télécharge automatiquement toutes les images dans chaque article et les sauvegarde sur l\'appareil. En fonction du nombre d\'articles de votre instance wallabag, cela peut prendre un moment et utiliser beaucoup d\'espace disque sur votre appareil.</string>
     <string name="pref_name_storage_dbPath">Emplacement de la base de données</string>
     <string name="pref_name_storage_dbPath_internalStorage">Stockage interne</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Stockage externe</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Stockage externe: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">La base de données a été déplacée</string>
     <string name="pref_categoryName_miscellaneous">Divers</string>
     <string name="pref_name_misc_appendWallabagMention">Ajouter la mention wallabag</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -212,7 +212,7 @@
     <string name="pref_name_misc_wipeDB_confirmTitle">Izbrisati bazu podataka\?</string>
     <string name="pref_name_tts_showPreviewAsAlbumArt">Pregledaj sliku kao grafiku albuma</string>
     <string name="themeName_dark">Tamna</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Vanjsko spremište</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Vanjsko spremište: %s</string>
     <string name="pref_name_ui_readingSpeed">Brzina čitanja</string>
     <string name="pref_name_ui_previewImage_enabled">Pretprikaz slike</string>
     <string name="notification_channel_group_name_sync">Sinkroniziranje</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -251,7 +251,7 @@
     <string name="pref_desc_ui_disableTouch_keyCode">Nyomja meg itt az érintéses bevitelt tiltó/engedélyező gomb beállításához</string>
     <string name="pref_name_storage_dbPath">Adatbázis helye</string>
     <string name="pref_name_storage_dbPath_internalStorage">Belső tárhely</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Külső tárhely</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Külső tárhely: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">Az adatbázis elköltözött</string>
     <string name="pref_name_misc_appendWallabagMention">Mellékelje a wallabag-ra való utalást</string>
     <string name="pref_desc_misc_appendWallabagMention">Hozzáfűzi \"a @wallabagapp segítségével\"-t a megosztott szövegekhez</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -276,7 +276,7 @@
     <string name="pref_categoryName_misc_localQueue">Cambiamenti locali</string>
     <string name="pref_desc_misc_appendWallabagMention">Aggiungi «via @wallabagapp» ai testi condivisi</string>
     <string name="pref_name_storage_dbPath_dbMoved">Banca dati spostata</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Archiviazione esterna</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Archiviazione esterna: %s</string>
     <string name="pref_name_storage_dbPath_internalStorage">Archiviazione interna</string>
     <string name="pref_name_storage_dbPath">Posizione della banca dati</string>
     <string name="pref_name_ui_previewImage_enabled">Anteprima immagine</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -252,7 +252,7 @@
     <string name="pref_desc_ui_disableTouch_keyCode">ここを押して、タッチ入力を無効/有効にするために使用するボタンを設定します</string>
     <string name="pref_name_storage_dbPath">データベースの場所</string>
     <string name="pref_name_storage_dbPath_internalStorage">内部ストレージ</string>
-    <string name="pref_name_storage_dbPath_externalStorage">外部ストレージ</string>
+    <string name="pref_name_storage_dbPath_externalStorage">外部ストレージ: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">データベースを移動しました</string>
     <string name="pref_name_misc_appendWallabagMention">wallabag のメンションを追加</string>
     <string name="pref_desc_misc_appendWallabagMention">共有テキストに \"via @wallabagapp\" を追加</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -49,7 +49,7 @@
     <string name="pref_name_autoSync_type">자동 동기화 유형</string>
     <string name="pref_name_ui_screenScrolling_smooth">부드러운 스크롤 사용</string>
     <string name="menu_open_random_article">랜덤 기사 열기</string>
-    <string name="pref_name_storage_dbPath_externalStorage">외부 저장소</string>
+    <string name="pref_name_storage_dbPath_externalStorage">외부 저장소: %s</string>
     <string name="checkCredentials_progressDialogMessage">API 액세스를 테스트하는 중…</string>
     <string name="pref_categoryName_connection_advanced">고급 연결 설정</string>
     <string name="noNextArticle">현재 목록에 더 이상 기사 없음</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -250,7 +250,7 @@
     <string name="pref_desc_ui_disableTouch_keyCode">Trykk her for å sette opp tasten brukt for å skru på/av trykkinndata</string>
     <string name="pref_name_storage_dbPath">Databaseplassering</string>
     <string name="pref_name_storage_dbPath_internalStorage">Internt lagringsmedium</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Eksternt lagringsmedium</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Eksternt lagringsmedium: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">Database flyttet</string>
     <string name="pref_name_misc_appendWallabagMention">Legg til wallabag-nevning</string>
     <string name="pref_desc_misc_appendWallabagMention">Legg til \"via @wallabagapp\" i delte tekster</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -246,7 +246,7 @@
     <string name="pref_name_misc_appendWallabagMention">Voeg wallabag vermelding toe</string>
     <string name="pref_categoryName_miscellaneous">Overig</string>
     <string name="pref_name_storage_dbPath_dbMoved">Database verplaatst</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Externe opslag</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Externe opslag: %s</string>
     <string name="pref_name_storage_dbPath_internalStorage">Interne opslag</string>
     <string name="pref_name_storage_dbPath">Database locatie</string>
     <string name="pref_desc_imageCache_enabled">Download automatisch alle afbeeldingen van elk artikel en sla deze op het apparaat op. Afhankelijke van de lengte van uw wallabag artikel lijst kan dit veel tijd en opslag in beslag nemen.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -268,7 +268,7 @@
     <string name="pref_desc_ui_scrollOverBottom">Ustaw, ile razy przewinięcie poza dół oznacza artykuł jako przeczytany</string>
     <string name="pref_name_storage_dbPath">Lokalizacja bazy danych</string>
     <string name="pref_name_storage_dbPath_internalStorage">Pamięć wewnętrzna</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Pamięć zewnętrzna</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Pamięć zewnętrzna: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">Baza danych została przeniesiona</string>
     <string name="pref_name_misc_appendWallabagMention">Dołącz wzmiankę o wallabag</string>
     <string name="pref_desc_misc_appendWallabagMention">Dołącz \"przez @wallabagapp\" do udostępnionych tekstów</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -122,7 +122,7 @@
     <string name="connectionWizard_provider_wallabagit_prev">Voltar</string>
     <string name="connectionWizard_summary_prev">Voltar</string>
     <string name="notification_downloadingImages">Baixando imagens</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Armazenamento externo</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Armazenamento externo: %s</string>
     <string name="notification_channel_name_error">Erros</string>
     <string name="notification_error">Erro</string>
     <string name="notification_expandedError">Erro: %s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -261,7 +261,7 @@
     <string name="pref_desc_ui_scrollOverBottom">Количество раз, которое вам нужно прокрутить вниз, чтобы отметить статью как прочитанную</string>
     <string name="pref_name_storage_dbPath">Расположение базы данных</string>
     <string name="pref_name_storage_dbPath_internalStorage">Внутренняя память</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Внешний накопитель</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Внешний накопитель: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">База данных перемещена</string>
     <string name="pref_name_misc_appendWallabagMention">Добавлять упоминание wallabag</string>
     <string name="pref_desc_misc_appendWallabagMention">Добавлять \"через @wallabagapp\" к тексту</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -263,7 +263,7 @@
     <string name="pref_desc_ui_scrollOverBottom">Kaç kez en alta kaydırmanın bir makaleyi okundu olarak işaretlediğini ayarlayın</string>
     <string name="pref_name_storage_dbPath">Veri tabanı konumu</string>
     <string name="pref_name_storage_dbPath_internalStorage">Dahili hafıza</string>
-    <string name="pref_name_storage_dbPath_externalStorage">Harici hafıza</string>
+    <string name="pref_name_storage_dbPath_externalStorage">Harici hafıza: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">Veri tabanı taşındı</string>
     <string name="pref_name_misc_appendWallabagMention">wallabag alıntısını sonuna ekle</string>
     <string name="pref_desc_misc_appendWallabagMention">Paylaşılan metinlerin sonuna \"via @wallabagapp\" ekle</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -232,7 +232,7 @@
     <string name="pref_desc_imageCache_enabled">自动下载每篇文章的所有图片到设备上（如果文章列表很长，会占用很多时间和空间）</string>
     <string name="pref_name_storage_dbPath">数据库位置</string>
     <string name="pref_name_storage_dbPath_internalStorage">内部存储</string>
-    <string name="pref_name_storage_dbPath_externalStorage">外部存储</string>
+    <string name="pref_name_storage_dbPath_externalStorage">外部存储: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">数据库已移动</string>
     <string name="pref_categoryName_miscellaneous">杂项</string>
     <string name="pref_name_misc_appendWallabagMention">附加 walabag 水印</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,7 +292,7 @@
 
     <string name="pref_name_storage_dbPath">Database location</string>
     <string name="pref_name_storage_dbPath_internalStorage">Internal storage</string>
-    <string name="pref_name_storage_dbPath_externalStorage">External storage</string>
+    <string name="pref_name_storage_dbPath_externalStorage">External storage: %s</string>
     <string name="pref_name_storage_dbPath_dbMoved">Database moved</string>
 
     <string name="pref_categoryName_miscellaneous">Miscellaneous</string>


### PR DESCRIPTION
Allow choosing from all returned external writable storage locations for article and image cache, instead of just the first one; show the path for each returned location so the user can decide which one is best for them.  On many devices, selecting "External Storage" ended up choosing a path pointing to the emulated external storage Android provides, which on devices with small internal memory and with large wallabag databases can take up significant space.  This change allows those users to choose their SD card instead for storage.