### PR TITLE
Fix foreground service crashes when launching tts SDK > 33

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/tts/TtsService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/tts/TtsService.java
@@ -14,6 +14,7 @@ import android.graphics.Bitmap;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.SystemClock;

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/tts/TtsService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/tts/TtsService.java
@@ -1139,9 +1139,9 @@ public class TtsService extends Service {
             if (!isForeground) {
                 Log.v(TAG, "setForegroundAndNotification() startForeground()");
                 if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.TIRAMISU) {
-                    startForeground(NOTIFICATION_ID, generateNotification())
+                    startForeground(NOTIFICATION_ID, generateNotification());
                 } else {
-                    startForeground(NOTIFICATION_ID, generateNotification(), FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+                    startForeground(NOTIFICATION_ID, generateNotification(), FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
                 }
                 isForeground = true;
             }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/tts/TtsService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/tts/TtsService.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
 import android.graphics.Bitmap;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
@@ -1142,7 +1143,7 @@ public class TtsService extends Service {
                 if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.TIRAMISU) {
                     startForeground(NOTIFICATION_ID, generateNotification());
                 } else {
-                    startForeground(NOTIFICATION_ID, generateNotification(), FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+                    startForeground(NOTIFICATION_ID, generateNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
                 }
                 isForeground = true;
             }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/tts/TtsService.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/tts/TtsService.java
@@ -1138,7 +1138,11 @@ public class TtsService extends Service {
         if (foreground) {
             if (!isForeground) {
                 Log.v(TAG, "setForegroundAndNotification() startForeground()");
-                startForeground(NOTIFICATION_ID, generateNotification());
+                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.TIRAMISU) {
+                    startForeground(NOTIFICATION_ID, generateNotification())
+                } else {
+                    startForeground(NOTIFICATION_ID, generateNotification(), FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+                }
                 isForeground = true;
             }
         } else {


### PR DESCRIPTION
Fix for crashes when launching the tts service in SDK versions greater than 33.
Linked issue https://github.com/wallabag/android-app/issues/1348