### PR TITLE
Add FOREGROUND_SERVICE permission to allow TTS service to stop crashing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="22"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 


### PR DESCRIPTION
Fixes #1391 

This adds the `android.permission.FOREGROUND_SERVICE` required for Android 14 (and maybe lower) to prevent security crashes from happening when Text to Speech is started.

I'm happy to make tweaks if needed!