### PR TITLE
call invalidate() to refresh the customized menu

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -400,9 +400,7 @@ public class ReadArticleActivity extends BaseActionBarActivity {
     @Override
     public void onActionModeStarted(ActionMode mode) {
         Menu menu = mode.getMenu();
-
         mode.getMenuInflater().inflate(R.menu.read_article_activity, menu);
-
         menu.findItem(R.id.menu_tag).setOnMenuItemClickListener(item -> {
             webViewContent.evaluateJavascript(
                     "(function(){return window.getSelection().toString()})()",
@@ -421,7 +419,8 @@ public class ReadArticleActivity extends BaseActionBarActivity {
         } else {
             annotateItem.setVisible(false);
         }
-
+        // refresh menu content
+        mode.invalidate();
         super.onActionModeStarted(mode);
     }
 


### PR DESCRIPTION
This commit is calling the invalidate() on the action mode object, where we customize the menu with the added tagging and annotation buttons. This refreshes the menu object. Then the menu items are directly shown after selecting text in the article view.

fixes #1431