### PR TITLE
Autohide toolbar on scroll

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/MainActivity.java
@@ -32,6 +32,7 @@ import androidx.core.view.GravityCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 
+import com.google.android.material.appbar.AppBarLayout;
 import com.google.android.material.navigation.NavigationView;
 import com.mikepenz.aboutlibraries.Libs;
 import com.mikepenz.aboutlibraries.LibsBuilder;
@@ -297,6 +298,9 @@ public class MainActivity extends AppCompatActivity
     @Override
     protected void onResume() {
         super.onResume();
+
+        AppBarLayout appBarLayout = findViewById(R.id.app_bar);
+        appBarLayout.setExpanded(true, true);
 
         // TODO: check logic
         if (checkConfigurationOnResume) {

--- a/app/src/main/res/layout/activity_main_appbar.xml
+++ b/app/src/main/res/layout/activity_main_appbar.xml
@@ -9,31 +9,38 @@
     tools:context="fr.gaulupeau.apps.Poche.ui.MainActivity">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="?attr/appBarOverlayTheme">
 
-        <FrameLayout
+        <com.google.android.material.appbar.CollapsingToolbarLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            app:layout_scrollFlags="scroll|enterAlways|snap">
 
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
+            <FrameLayout
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
-                android:background="?attr/colorPrimary"
-                app:popupTheme="?attr/popupOverlayTheme"/>
+                app:layout_collapseMode="pin">
 
-            <ProgressBar
-                android:id="@+id/progressBar"
-                android:layout_width="match_parent"
-                android:layout_height="10dp"
-                android:visibility="gone"
-                android:layout_gravity="bottom"
-                style="?android:attr/progressBarStyleHorizontal"/>
+                <androidx.appcompat.widget.Toolbar
+                    android:id="@+id/toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    android:background="?attr/colorPrimary"
+                    app:popupTheme="?attr/popupOverlayTheme"/>
 
-        </FrameLayout>
+                <ProgressBar
+                    android:id="@+id/progressBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="10dp"
+                    android:visibility="gone"
+                    android:layout_gravity="bottom"
+                    style="?android:attr/progressBarStyleHorizontal"/>
+            </FrameLayout>
 
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout/article.xml
+++ b/app/src/main/res/layout/article.xml
@@ -1,18 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/viewMain"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="fr.gaulupeau.apps.Poche.ui.ReadArticleActivity">
 
-    <ScrollView
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:theme="?attr/actionBarTheme"
+            app:layout_scrollFlags="scroll|enterAlways|snap" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/scroll"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:ignore="UselessParent">
 
         <LinearLayout
@@ -23,22 +38,22 @@
 
             <WebView
                 android:id="@+id/webViewContent"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:paddingLeft="15sp"
-                android:paddingRight="15sp">
+                android:paddingLeft="15dp"
+                android:paddingRight="15dp">
 
                 <View
                     android:id="@+id/view1"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="1dip"
-                    android:layout_marginBottom="5sp"
-                    android:layout_marginTop="5sp"
+                    android:layout_marginBottom="5dp"
+                    android:layout_marginTop="5dp"
                     android:background="#000000"
                     android:visibility="gone"/>
 
@@ -52,7 +67,7 @@
 
                 <LinearLayout
                     android:id="@+id/bottomTools"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
                     android:visibility="gone">
@@ -89,6 +104,6 @@
 
         </LinearLayout>
 
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -45,13 +45,14 @@
         <item name="icon_autoplay">@drawable/ic_redo_24dp</item>
         <item name="icon_menu">@drawable/ic_menu_24dp</item>
         <item name="android:textColorPrimary">@color/darkContrastBlack</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
     </style>
 
     <style name="LightTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
     </style>
     <style name="LightTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
     <style name="LightTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>
@@ -64,7 +65,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
     </style>
 
     <style name="DarkTheme" parent="Theme.AppCompat">
@@ -86,13 +87,14 @@
         <item name="icon_fast_rewind">@drawable/ic_fast_rewind_white_24dp</item>
         <item name="icon_autoplay">@drawable/ic_redo_white_24dp</item>
         <item name="icon_menu">@drawable/ic_menu_white_24dp</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
     </style>
 
     <style name="DarkTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
     </style>
     <style name="DarkTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.ActionBar"/>
     <style name="DarkTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Dark"/>
@@ -108,7 +110,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
     </style>
 
     <style name="SolarizedTheme" parent="Theme.AppCompat.Light" >
@@ -148,7 +150,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
     </style>
     <style name="SolarizedTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.ActionBar"/>
     <style name="SolarizedTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light">


### PR DESCRIPTION
This PR aims to improve reading experience as well as add a modern touch while not breaking a thing.


https://github.com/user-attachments/assets/6454b73a-114b-425d-9209-c67a49877d9f


- replaced actionbar with toolbar on article screen and made it collapse/show on scroll
- preserving current fullscreen mode state (hide article toolbar)
- collapse the mainactivity toolbar on scroll and automatically show it with onResume
- improved status bar coloring consistency – match toolbar (primarycolor) to make the collapsed state more appealing
- tested with all themes, as I didn't want to break anything
- fixed some deprecated values (sp, fill_parent)

Closes https://github.com/wallabag/android-app/issues/1215 https://github.com/wallabag/android-app/issues/114 https://github.com/wallabag/android-app/issues/442