### PR TITLE
Fix: http schema handling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,7 +89,6 @@
 
                 <data android:scheme="http" />
                 <data android:scheme="https" />
-                <data android:host="app.wallabag.it" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -99,7 +98,6 @@
 
                 <data android:scheme="http" />
                 <data android:scheme="https" />
-                <data android:host="app.wallabag.it" />
                 <data android:mimeType="text/html" />
                 <data android:mimeType="text/plain" />
                 <data android:mimeType="application/xhtml+xml" />


### PR DESCRIPTION
The fr.gaulupeau.apps.Poche.ui.HttpSchemeHandlerActivity is supposed to be able to handle any http or https url. 

However, as part of the change in #1434, this functionality was broken, it is not no longer possible to set wallabag to handle http scheme even when the setting option is set to true.

Reverting the change fixes this issue.

