### PR TITLE
Add customisable automatic dark/light theme switching

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -448,6 +448,14 @@ public class Settings {
         setString(R.string.pref_key_ui_theme, theme.toString());
     }
 
+    public boolean isAutoThemeEnabled() {
+        return getBoolean(R.string.pref_key_ui_theme_auto, false);
+    }
+
+    public void setAutoThemeEnabled(boolean value) {
+        setBoolean(R.string.pref_key_ui_theme_auto, value);
+    }
+
     public boolean isVolumeButtonsScrollingEnabled() {
         return getBoolean(R.string.pref_key_ui_volumeButtonsScrolling_enabled, false);
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/data/Settings.java
@@ -456,6 +456,36 @@ public class Settings {
         setBoolean(R.string.pref_key_ui_theme_auto, value);
     }
 
+    public Themes.Theme getAutoLightTheme() {
+        String themeName = getString(R.string.pref_key_ui_theme_auto_light);
+        Themes.Theme theme = null;
+        if(themeName != null) {
+            try {
+                theme = Themes.Theme.valueOf(themeName);
+            } catch(IllegalArgumentException ignored) {}
+        }
+        return theme != null ? theme : Themes.Theme.LIGHT;
+    }
+
+    public void setAutoLightTheme(Themes.Theme theme) {
+        setString(R.string.pref_key_ui_theme_auto_light, theme.toString());
+    }
+
+    public Themes.Theme getAutoDarkTheme() {
+        String themeName = getString(R.string.pref_key_ui_theme_auto_dark);
+        Themes.Theme theme = null;
+        if(themeName != null) {
+            try {
+                theme = Themes.Theme.valueOf(themeName);
+            } catch(IllegalArgumentException ignored) {}
+        }
+        return theme != null ? theme : Themes.Theme.DARK;
+    }
+
+    public void setAutoDarkTheme(Themes.Theme theme) {
+        setString(R.string.pref_key_ui_theme_auto_dark, theme.toString());
+    }
+
     public boolean isVolumeButtonsScrollingEnabled() {
         return getBoolean(R.string.pref_key_ui_volumeButtonsScrolling_enabled, false);
     }

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
@@ -9,6 +9,8 @@ import java.util.WeakHashMap;
 
 import fr.gaulupeau.apps.InThePoche.R;
 import fr.gaulupeau.apps.Poche.App;
+import android.content.Context;
+import android.content.res.Configuration;
 
 public class Themes {
 
@@ -28,23 +30,38 @@ public class Themes {
         return theme;
     }
 
+    public static Theme getResolvedTheme(Context context) {
+        if (App.getSettings().isAutoThemeEnabled()) {
+            int currentNightMode = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+            if (currentNightMode == Configuration.UI_MODE_NIGHT_YES) {
+                return Theme.DARK;
+            } else {
+                return Theme.LIGHT;
+            }
+        }
+        return theme;
+    }
+
     public static void applyTheme(Activity activity) {
         applyTheme(activity, true);
     }
 
     public static void applyTheme(Activity activity, boolean actionBar) {
-        activity.setTheme(actionBar ? theme.getResId() : theme.getNoActionBarResId());
-        appliedThemes.put(activity, theme);
+        Theme resolvedTheme = getResolvedTheme(activity);
+        activity.setTheme(actionBar ? resolvedTheme.getResId() : resolvedTheme.getNoActionBarResId());
+        appliedThemes.put(activity, resolvedTheme);
     }
 
     public static void applyDialogTheme(Activity activity) {
-        activity.setTheme(theme.getDialogResId());
-        appliedThemes.put(activity, theme);
+        Theme resolvedTheme = getResolvedTheme(activity);
+        activity.setTheme(resolvedTheme.getDialogResId());
+        appliedThemes.put(activity, resolvedTheme);
     }
 
     public static void checkTheme(Activity activity) {
         Theme appliedTheme = appliedThemes.get(activity);
-        if(appliedTheme != theme) activity.recreate();
+        Theme resolvedTheme = getResolvedTheme(activity);
+        if(appliedTheme != resolvedTheme) activity.recreate();
     }
 
     public enum Theme {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/Themes.java
@@ -34,9 +34,9 @@ public class Themes {
         if (App.getSettings().isAutoThemeEnabled()) {
             int currentNightMode = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
             if (currentNightMode == Configuration.UI_MODE_NIGHT_YES) {
-                return Theme.DARK;
+                return App.getSettings().getAutoDarkTheme();
             } else {
-                return Theme.LIGHT;
+                return App.getSettings().getAutoLightTheme();
             }
         }
         return theme;
@@ -69,55 +69,67 @@ public class Themes {
                 R.string.themeName_light,
                 R.style.LightTheme,
                 R.style.LightTheme_NoActionBar,
-                R.style.DialogTheme
+                R.style.DialogTheme,
+                false
         ),
 
         LIGHT_CONTRAST(
                 R.string.themeName_light_contrast,
                 R.style.LightThemeContrast,
                 R.style.LightThemeContrast_NoActionBar,
-                R.style.DialogTheme
+                R.style.DialogTheme,
+                false
         ),
 
         E_INK(
                 R.string.themeName_eink,
                 R.style.LightThemeContrast,
                 R.style.LightThemeContrast_NoActionBar,
-                R.style.DialogTheme
+                R.style.DialogTheme,
+                false
         ),
 
         DARK(
                 R.string.themeName_dark,
                 R.style.DarkTheme,
                 R.style.DarkTheme_NoActionBar,
-                R.style.DialogThemeDark
+                R.style.DialogThemeDark,
+                true
         ),
 
         DARK_CONTRAST(
                 R.string.themeName_dark_contrast,
                 R.style.DarkThemeContrast,
                 R.style.DarkThemeContrast_NoActionBar,
-                R.style.DialogThemeDark
+                R.style.DialogThemeDark,
+                true
         ),
 
         SOLARIZED(
                 R.string.themeName_solarized,
                 R.style.SolarizedTheme,
                 R.style.SolarizedTheme_NoActionBar,
-                R.style.DialogTheme
+                R.style.DialogTheme,
+                true
         );
 
         private int nameId;
         private int resId;
         private int noActionBarResId;
         private int dialogResId;
+        private boolean isDark;
 
         Theme(@StringRes int nameId, @StyleRes int resId,
-              @StyleRes int noActionBarResId, @StyleRes int dialogResId) {
+              @StyleRes int noActionBarResId, @StyleRes int dialogResId, boolean isDark) {
             this.nameId = nameId;
             this.resId = resId;
             this.noActionBarResId = noActionBarResId;
             this.dialogResId = dialogResId;
+            this.isDark = isDark;
+        }
+
+        public boolean isDark() {
+            return isDark;
         }
 
         public @StringRes int getNameId() {

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -77,6 +77,8 @@ public class SettingsActivity extends BaseActionBarActivity {
                 R.string.pref_key_connection_api_clientID,
                 R.string.pref_key_connection_api_clientSecret,
                 R.string.pref_key_ui_theme,
+                R.string.pref_key_ui_theme_auto_light,
+                R.string.pref_key_ui_theme_auto_dark,
                 R.string.pref_key_ui_article_fontSize,
                 R.string.pref_key_ui_screenScrolling_percent,
                 R.string.pref_key_autoSync_interval,
@@ -145,6 +147,38 @@ public class SettingsActivity extends BaseActionBarActivity {
 
                 themeListPreference.setEntries(themeEntries);
                 themeListPreference.setEntryValues(themeEntryValues);
+            }
+
+            ListPreference autoLightThemePreference = (ListPreference)findPreference(
+                    getString(R.string.pref_key_ui_theme_auto_light));
+            if(autoLightThemePreference != null) {
+                Themes.Theme[] themes = Themes.Theme.values();
+                List<String> entries = new ArrayList<>();
+                List<String> values = new ArrayList<>();
+                for (Themes.Theme t : themes) {
+                    if (!t.isDark()) {
+                        entries.add(getString(t.getNameId()));
+                        values.add(t.toString());
+                    }
+                }
+                autoLightThemePreference.setEntries(entries.toArray(new String[0]));
+                autoLightThemePreference.setEntryValues(values.toArray(new String[0]));
+            }
+
+            ListPreference autoDarkThemePreference = (ListPreference)findPreference(
+                    getString(R.string.pref_key_ui_theme_auto_dark));
+            if(autoDarkThemePreference != null) {
+                Themes.Theme[] themes = Themes.Theme.values();
+                List<String> entries = new ArrayList<>();
+                List<String> values = new ArrayList<>();
+                for (Themes.Theme t : themes) {
+                    if (t.isDark()) {
+                        entries.add(getString(t.getNameId()));
+                        values.add(t.toString());
+                    }
+                }
+                autoDarkThemePreference.setEntries(entries.toArray(new String[0]));
+                autoDarkThemePreference.setEntryValues(values.toArray(new String[0]));
             }
 
             ListPreference autoSyncIntervalListPreference = (ListPreference)findPreference(
@@ -715,6 +749,8 @@ public class SettingsActivity extends BaseActionBarActivity {
                     break;
 
                 case R.string.pref_key_ui_theme:
+                case R.string.pref_key_ui_theme_auto_light:
+                case R.string.pref_key_ui_theme_auto_dark:
                 case R.string.pref_key_autoSync_interval:
                 case R.string.pref_key_autoSync_type:
                     setListSummaryFromContent(key);

--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/preferences/SettingsActivity.java
@@ -431,6 +431,12 @@ public class SettingsActivity extends BaseActionBarActivity {
                     themeChanged = true;
                     break;
 
+                case R.string.pref_key_ui_theme_auto:
+                case R.string.pref_key_ui_theme_auto_light:
+                case R.string.pref_key_ui_theme_auto_dark:
+                    themeChanged = true;
+                    break;
+
                 case R.string.pref_key_autoSync_enabled:
                     autoSyncChanged = true;
                     break;

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -29,6 +29,8 @@
     <string name="pref_key_ui_tagList_sortOrder" translatable="false">ui.tagList.sortOrder</string>
     <string name="pref_key_ui_theme" translatable="false">ui.theme</string>
     <string name="pref_key_ui_theme_auto" translatable="false">ui.theme.auto</string>
+    <string name="pref_key_ui_theme_auto_light" translatable="false">ui.theme.auto.light</string>
+    <string name="pref_key_ui_theme_auto_dark" translatable="false">ui.theme.auto.dark</string>
     <string name="pref_key_ui_volumeButtonsScrolling_enabled" translatable="false">ui.volumeButtonsScrolling.enabled</string>
     <string name="pref_key_ui_tapToScroll_enabled" translatable="false">ui.tapToScroll.enabled</string>
     <string name="pref_key_ui_screenScrolling" translatable="false">ui.screenScrolling</string>

--- a/app/src/main/res/values/strings-preference-keys.xml
+++ b/app/src/main/res/values/strings-preference-keys.xml
@@ -28,6 +28,7 @@
     <string name="pref_key_ui_lists_sortOrder" translatable="false">ui.lists.sortOrder</string>
     <string name="pref_key_ui_tagList_sortOrder" translatable="false">ui.tagList.sortOrder</string>
     <string name="pref_key_ui_theme" translatable="false">ui.theme</string>
+    <string name="pref_key_ui_theme_auto" translatable="false">ui.theme.auto</string>
     <string name="pref_key_ui_volumeButtonsScrolling_enabled" translatable="false">ui.volumeButtonsScrolling.enabled</string>
     <string name="pref_key_ui_tapToScroll_enabled" translatable="false">ui.tapToScroll.enabled</string>
     <string name="pref_key_ui_screenScrolling" translatable="false">ui.screenScrolling</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,10 @@
     <string name="pref_name_ui_theme">App theme</string>
     <string name="pref_name_ui_theme_auto">Auto dark mode</string>
     <string name="pref_desc_ui_theme_auto">Switch between light and dark theme based on system settings</string>
+    <string name="pref_name_ui_theme_auto_light">Auto light theme</string>
+    <string name="pref_desc_ui_theme_auto_light">Theme to use when system is in light mode</string>
+    <string name="pref_name_ui_theme_auto_dark">Auto dark theme</string>
+    <string name="pref_desc_ui_theme_auto_dark">Theme to use when system is in dark mode</string>
     <string name="pref_name_ui_article_fontSize" formatted="false">Article text size (%)</string>
     <string name="pref_name_ui_article_fontSerif">Serif typeface</string>
     <string name="pref_desc_ui_article_fontSerif">Serif font for articles</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,6 +201,8 @@
 
     <string name="pref_categoryName_ui">UI</string>
     <string name="pref_name_ui_theme">App theme</string>
+    <string name="pref_name_ui_theme_auto">Auto dark mode</string>
+    <string name="pref_desc_ui_theme_auto">Switch between light and dark theme based on system settings</string>
     <string name="pref_name_ui_article_fontSize" formatted="false">Article text size (%)</string>
     <string name="pref_name_ui_article_fontSerif">Serif typeface</string>
     <string name="pref_desc_ui_article_fontSerif">Serif font for articles</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -84,6 +84,20 @@
                 android:title="@string/pref_name_ui_theme_auto"
                 android:summary="@string/pref_desc_ui_theme_auto"
                 android:defaultValue="false"/>
+            <ListPreference
+                android:dependency="@string/pref_key_ui_theme_auto"
+                android:key="@string/pref_key_ui_theme_auto_light"
+                android:title="@string/pref_name_ui_theme_auto_light"
+                android:summary="@string/pref_desc_ui_theme_auto_light"
+                android:dialogTitle="@string/pref_name_ui_theme_auto_light"
+                android:defaultValue="LIGHT"/>
+            <ListPreference
+                android:dependency="@string/pref_key_ui_theme_auto"
+                android:key="@string/pref_key_ui_theme_auto_dark"
+                android:title="@string/pref_name_ui_theme_auto_dark"
+                android:summary="@string/pref_desc_ui_theme_auto_dark"
+                android:dialogTitle="@string/pref_name_ui_theme_auto_dark"
+                android:defaultValue="DARK"/>
             <fr.gaulupeau.apps.Poche.ui.preferences.IntEditTextPreference
                 android:key="@string/pref_key_ui_article_fontSize"
                 android:title="@string/pref_name_ui_article_fontSize"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -79,6 +79,11 @@
                 android:title="@string/pref_name_ui_theme"
                 android:dialogTitle="@string/pref_name_ui_theme"
                 android:defaultValue="LIGHT"/>
+            <CheckBoxPreference
+                android:key="@string/pref_key_ui_theme_auto"
+                android:title="@string/pref_name_ui_theme_auto"
+                android:summary="@string/pref_desc_ui_theme_auto"
+                android:defaultValue="false"/>
             <fr.gaulupeau.apps.Poche.ui.preferences.IntEditTextPreference
                 android:key="@string/pref_key_ui_article_fontSize"
                 android:title="@string/pref_name_ui_article_fontSize"


### PR DESCRIPTION
## Summary
This PR adds the ability for the app to automatically switch between dark and light themes based on the system's dark mode settings. It also allows the user to select which specific light and dark themes they prefer to use for this automatic switching.

## Features Added
- **Auto dark mode toggle**: A new setting to enable/disable automatic theme switching based on system configuration.
- **Customizable auto-themes**: When auto mode is enabled, users can select:
    - Their preferred **Auto light theme** (from available light themes like Light, Light Contrast, E-Ink).
    - Their preferred **Auto dark theme** (from available dark themes like Dark, Dark Contrast, Solarized).
- **Immediate updates**: Changing the settings applies the theme immediately without requiring an app restart.

## Technical Details
- Updated `Themes.java` to support an `isDark` flag and resolve the theme dynamically based on system `uiMode` and stored preferences.
- Added new string keys and UI preferences in `preferences.xml`.
- Updated `SettingsActivity.java` to populate the filtered dropdowns and handle preference change listeners for immediate UI updates.

## Verification
- Verified that the code compiles successfully with Java 21 and Android SDK 34.
<img width="477" height="1080" alt="Android" src="https://github.com/user-attachments/assets/e41fe17e-7e50-4079-9e42-df9e2711d31b" />
