### PR TITLE
Disable WebView file access when the image cache is off

### DIFF
--- a/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
+++ b/app/src/main/java/fr/gaulupeau/apps/Poche/ui/ReadArticleActivity.java
@@ -646,9 +646,10 @@ public class ReadArticleActivity extends AppCompatActivity {
         WebSettings webViewSettings = webViewContent.getSettings();
         webViewSettings.setJavaScriptEnabled(true);
 
-        if (settings.isImageCacheEnabled() && !webViewSettings.getAllowFileAccess()) {
-            Log.d(TAG, "initWebView() enabling WebView file access");
-            webViewSettings.setAllowFileAccess(true);
+        boolean needsFileAccess = settings.isImageCacheEnabled();
+        if (webViewSettings.getAllowFileAccess() != needsFileAccess) {
+            Log.d(TAG, "initWebView() setting WebView file access to " + needsFileAccess);
+            webViewSettings.setAllowFileAccess(needsFileAccess);
         }
 
         initTtsController();


### PR DESCRIPTION
Closes #1496.

`ReadArticleActivity.initWebView()` already gates `setAllowFileAccess(true)` on the image cache being enabled, but the gate is one-directional:

```java
if (settings.isImageCacheEnabled() && !webViewSettings.getAllowFileAccess()) {
    Log.d(TAG, "initWebView() enabling WebView file access");
    webViewSettings.setAllowFileAccess(true);
}
```

It only enables the flag, it never disables it. On `minSdkVersion 23` the WebView default for `setAllowFileAccess` is `true` on Android 9 and below, so a WebView on those versions kept file URL access regardless of whether the user had the image cache turned on. The article WebView also attaches two JS bridges (`hostWebViewTextController`, `hostAnnotationController`), which is what makes the lingering flag matter.

### Change

Make the flag mirror the cache setting explicitly:

```java
boolean needsFileAccess = settings.isImageCacheEnabled();
if (webViewSettings.getAllowFileAccess() != needsFileAccess) {
    Log.d(TAG, "initWebView() setting WebView file access to " + needsFileAccess);
    webViewSettings.setAllowFileAccess(needsFileAccess);
}
```

### Behaviour

- Image cache on: identical to before (file access on).
- Image cache off: file access is now explicitly off on pre-API-30 devices, not just API 30+.
- `loadDataWithBaseURL("file:///android_asset/", ...)` (the line that loads the article HTML further down) continues to work because the `android_asset` scheme is permitted regardless of this flag.